### PR TITLE
v2/API package upgradation to @ibm-cloud/ibm-schematics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Service Name | Import Path
 --- | ---
 [Schematics](https://cloud.ibm.com/apidocs/schematics) | @ibm-cloud/ibm-schematics/schematics/v1
 
-Service Name | Import Path
---- | ---
-[Schematics](https://cloud.ibm.com/apidocs/schematics) | @ibm-cloud/ibm-schematics/schematics/v2
 ## Prerequisites
 * You need an [IBM Cloud][ibm-cloud-onboarding] account.
 * **Node.js >=10**: This SDK is tested with Node.js versions 10 and up. It may work on previous versions but this is not officially supported.

--- a/schematics/v1.ts
+++ b/schematics/v1.ts
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.37.0-a85661cd-20210802-190136
+ * IBM OpenAPI SDK Code Generator Version: 3.64.0-959a5845-20230112-195144
  */
 
 import * as extend from 'extend';
@@ -24,10 +24,11 @@ import {
   Authenticator,
   BaseService,
   getAuthenticatorFromEnvironment,
-  getMissingParams,
+  validateParams,
   UserOptions,
 } from 'ibm-cloud-sdk-core';
 import { getSdkHeaders } from '../lib/common';
+import { getNewLogger, SDKLogger } from 'ibm-cloud-sdk-core';
 
 /**
  * IBM Cloud Schematics service is to provide the capability to manage resources  of cloud provider infrastructure by
@@ -36,10 +37,14 @@ import { getSdkHeaders } from '../lib/common';
  * calling the necessary actions on the infrastructure.  This principle is known as Infrastructure as Code.  For more
  * information, refer to [Getting started with IBM Cloud Schematics]
  * (https://cloud.ibm.com/docs/schematics?topic=schematics-getting-started).
+ *
+ * API Version: 1.0
  */
 
 class SchematicsV1 extends BaseService {
-  static DEFAULT_SERVICE_URL: string = 'https://schematics-dev.containers.appdomain.cloud';
+  static _logger: SDKLogger = getNewLogger('SchematicsV1');
+
+  static DEFAULT_SERVICE_URL: string = 'https://schematics.cloud.ibm.com';
 
   static DEFAULT_SERVICE_NAME: string = 'schematics';
 
@@ -102,7 +107,12 @@ class SchematicsV1 extends BaseService {
   /**
    * List supported schematics locations.
    *
-   * Retrieve a list of IBM Cloud locations where you can create Schematics workspaces.
+   * Retrieve a list of IBM Cloud locations where you can create the Schematics workspace or action. workspaces.
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions,
+   *   see [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -112,6 +122,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListSchematicsLocationParams
   ): Promise<SchematicsV1.Response<SchematicsV1.SchematicsLocations[]>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const sdkHeaders = getSdkHeaders(
       SchematicsV1.DEFAULT_SERVICE_NAME,
@@ -140,9 +156,14 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * List supported schematics locations.
+   * List supported locations.
    *
-   * Retrieve a list of IBM Cloud locations where you can work with Schematics objects.
+   * Retrieve a list of IBM Cloud locations where you can work with the Schematics objects.
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions,
+   *   see [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -152,8 +173,18 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListLocationsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.SchematicsLocationsList>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listLocations');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listLocations'
+    );
 
     const parameters = {
       options: {
@@ -179,6 +210,11 @@ class SchematicsV1 extends BaseService {
    * List resource groups.
    *
    * Retrieve a list of IBM Cloud resource groups that your account has access to.
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions,
+   *   see [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -188,8 +224,18 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListResourceGroupParams
   ): Promise<SchematicsV1.Response<SchematicsV1.ResourceGroupResponse[]>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listResourceGroup');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listResourceGroup'
+    );
 
     const parameters = {
       options: {
@@ -216,10 +262,6 @@ class SchematicsV1 extends BaseService {
    *
    * Retrieve detailed information about the IBM Cloud Schematics API version and the version of the provider plug-ins
    * that the API uses.
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to the
-   * workspace ID and the resource group. For more information, about Schematics access and permissions, see [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -229,6 +271,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.GetSchematicsVersionParams
   ): Promise<SchematicsV1.Response<SchematicsV1.VersionResponse>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const sdkHeaders = getSdkHeaders(
       SchematicsV1.DEFAULT_SERVICE_NAME,
@@ -257,14 +305,22 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Create metadata by  processing the template.
+   * Get variable metadata by parsing the template.
    *
-   * Create a Template metadata definition.
+   * Get the variable metadata from the template. This metadata can be passed in the payload during Schematics workspace
+   * create or update API call.
+   *  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.templateType - Template type (terraform, ansible, helm, cloudpak, bash script).
+   * @param {string} params.templateType - Template type such as **terraform**, **ansible**, **helm**, **cloudpak**, or
+   * **bash script**.
    * @param {ExternalSource} params.source - Source of templates, playbooks, or controls.
-   * @param {string} [params.region] - Region to which request should go. Applicable only on global endpoint.
+   * @param {string} [params.region] - Region on which request should process. Applicable only on global endpoint.
    * @param {string} [params.sourceType] - Type of source for the Template.
    * @param {string} [params.xGithubToken] - The personal access token to authenticate with your private GitHub or
    * GitLab repository and access your Terraform template.
@@ -275,11 +331,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ProcessTemplateMetaDataParams
   ): Promise<SchematicsV1.Response<SchematicsV1.TemplateMetaDataResponse>> {
     const _params = { ...params };
-    const requiredParams = ['templateType', 'source'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['templateType', 'source'];
+    const _validParams = ['templateType', 'source', 'region', 'sourceType', 'xGithubToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -326,21 +382,23 @@ class SchematicsV1 extends BaseService {
    *
    * Retrieve a list of Schematics workspaces from your IBM Cloud account that you have access to. The list of
    * workspaces that is returned depends on the API endpoint that you use. For example, if you use an API endpoint for a
-   * geography, such as North America, only workspaces that are created in `us-south` or `us-east` are returned. For
-   * more information about supported API endpoints, see [API endpoints](/apidocs/schematics#api-endpoints).
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to the
-   * workspace ID and the resource group. For more information, about Schematics access and permissions, see [Schematics
-   * service access roles and required
+   * geography, such as North America, only workspaces that are created in `us-south` or `us-east` are returned.
+   *  For more information about supported API endpoints, see [API endpoints](/apidocs/schematics#api-endpoints).
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions,
+   *   see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
    * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
    * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
-   * 2-6, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
    * `offset` option. Negative numbers are not supported and are ignored.
    * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
    * integer between 1 and 2000. If no value is provided, 100 is used by default.
+   * @param {string} [params.profile] - Level of details returned by the get method.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponseList>>}
    */
@@ -348,13 +406,24 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListWorkspacesParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponseList>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['offset', 'limit', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const query = {
       'offset': _params.offset,
       'limit': _params.limit,
+      'profile': _params.profile,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listWorkspaces');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listWorkspaces'
+    );
 
     const parameters = {
       options: {
@@ -385,9 +454,7 @@ class SchematicsV1 extends BaseService {
    * GitLab repository. Your workspace is then created with a **Draft** state. To later connect your workspace to a
    * GitHub or GitLab repository, you must use the `PUT /v1/workspaces/{id}` API to update the workspace or use the
    * `/v1/workspaces/{id}/templates/{template_id}/template_repo_upload` API to upload a TAR file instead.
-   *
    *  **Getting API endpoint**:-
-   *
    *  * The Schematics API endpoint that you use to create the workspace determines where your Schematics actions run
    * and your data is stored. See [API endpoints](/apidocs/schematics#api-endpoints) for more information.
    *  * If you use the API endpoint for a geography and not a specific location, such as North America, you can specify
@@ -398,7 +465,6 @@ class SchematicsV1 extends BaseService {
    * request body must match your API endpoint.
    *  * You also have the option to not specify a location in your API request body if you use a location-specific API
    * endpoint.
-   *
    *  **Getting IAM access token** :-
    *  * Before you create Schematics workspace, you need to create the IAM access token for your IBM Cloud Account.
    *  * To create IAM access token, use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>` and execute `curl -X POST
@@ -409,19 +475,17 @@ class SchematicsV1 extends BaseService {
    *  * You can set the environment values  `export ACCESS_TOKEN=<access_token>` and `export
    * REFRESH_TOKEN=<refresh_token>`.
    *  * You can use the obtained IAM access token in create workspace `curl` command.
-   *
-   *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *  to the workspace ID and the resource group.
-   *  For more information, about Schematics access and permissions,
-   *  see [Schematics service access roles and required
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions,
+   *   see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
-   * @param {string[]} [params.appliedShareddataIds] - List of applied shared dataset ID.
+   * @param {string[]} [params.appliedShareddataIds] - Deprecated: List of applied shared dataset ID.
    * @param {CatalogRef} [params.catalogRef] - Information about the software template that you chose from the IBM Cloud
    * catalog. This information is returned for IBM Cloud catalog offerings only.
+   * @param {Dependencies} [params.dependencies] - Workspace dependencies.
    * @param {string} [params.description] - The description of the workspace.
    * @param {string} [params.location] - The location where you want to create your Schematics workspace and run the
    * Schematics jobs. The location that you enter must match the API endpoint that you use. For example, if you use the
@@ -442,6 +506,7 @@ class SchematicsV1 extends BaseService {
    * workspace.
    * @param {string[]} [params.type] - List of Workspace type.
    * @param {WorkspaceStatusRequest} [params.workspaceStatus] - WorkspaceStatusRequest -.
+   * @param {string} [params.agentId] - agent id which is binded to with the workspace.
    * @param {string} [params.xGithubToken] - The personal access token to authenticate with your private GitHub or
    * GitLab repository and access your Terraform template.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -451,10 +516,17 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.CreateWorkspaceParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponse>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['appliedShareddataIds', 'catalogRef', 'dependencies', 'description', 'location', 'name', 'resourceGroup', 'sharedData', 'tags', 'templateData', 'templateRef', 'templateRepo', 'type', 'workspaceStatus', 'agentId', 'xGithubToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const body = {
       'applied_shareddata_ids': _params.appliedShareddataIds,
       'catalog_ref': _params.catalogRef,
+      'dependencies': _params.dependencies,
       'description': _params.description,
       'location': _params.location,
       'name': _params.name,
@@ -466,9 +538,14 @@ class SchematicsV1 extends BaseService {
       'template_repo': _params.templateRepo,
       'type': _params.type,
       'workspace_status': _params.workspaceStatus,
+      'agent_id': _params.agentId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'createWorkspace');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'createWorkspace'
+    );
 
     const parameters = {
       options: {
@@ -497,12 +574,9 @@ class SchematicsV1 extends BaseService {
    * Get workspace details.
    *
    * Retrieve detailed information for a workspace in your IBM Cloud account.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform
-   *  access to the workspace ID and the resource group. For more information,
-   *  about Schematics access and permissions, see [Schematics service access
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see [Schematics service access
    *  roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
@@ -514,18 +588,22 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetWorkspaceParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponse>> {
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
       'w_id': _params.wId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getWorkspace');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getWorkspace'
+    );
 
     const parameters = {
       options: {
@@ -553,14 +631,10 @@ class SchematicsV1 extends BaseService {
    *
    * Use this API to update or replace the entire workspace, including the Terraform template (`template_repo`) or IBM
    * Cloud catalog software template (`catalog_ref`) that your workspace points to.
-   *
    *  **Tip**:- If you want to update workspace metadata, use the `PATCH /v1/workspaces/{id}` API.
    *  To update workspace variables, use the `PUT /v1/workspaces/{id}/template_data/{template_id}/values` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -570,6 +644,7 @@ class SchematicsV1 extends BaseService {
    * @param {CatalogRef} [params.catalogRef] - Information about the software template that you chose from the IBM Cloud
    * catalog. This information is returned for IBM Cloud catalog offerings only.
    * @param {string} [params.description] - The description of the workspace.
+   * @param {Dependencies} [params.dependencies] - Workspace dependencies.
    * @param {string} [params.name] - The name of the workspace.
    * @param {SharedTargetData} [params.sharedData] - Information about the Target used by the templates originating from
    * the  IBM Cloud catalog offerings. This information is not relevant for workspace created using your own Terraform
@@ -581,6 +656,9 @@ class SchematicsV1 extends BaseService {
    * @param {WorkspaceStatusUpdateRequest} [params.workspaceStatus] - Input to update the workspace status.
    * @param {WorkspaceStatusMessage} [params.workspaceStatusMsg] - Information about the last job that ran against the
    * workspace. -.
+   * @param {string} [params.agentId] - agent id that process workspace jobs.
+   * @param {string} [params.xGithubToken] - The personal access token to authenticate with your private GitHub or
+   * GitLab repository and access your Terraform template.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponse>>}
    */
@@ -588,16 +666,17 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ReplaceWorkspaceParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponse>> {
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'catalogRef', 'description', 'dependencies', 'name', 'sharedData', 'tags', 'templateData', 'templateRepo', 'type', 'workspaceStatus', 'workspaceStatusMsg', 'agentId', 'xGithubToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
       'catalog_ref': _params.catalogRef,
       'description': _params.description,
+      'dependencies': _params.dependencies,
       'name': _params.name,
       'shared_data': _params.sharedData,
       'tags': _params.tags,
@@ -606,13 +685,18 @@ class SchematicsV1 extends BaseService {
       'type': _params.type,
       'workspace_status': _params.workspaceStatus,
       'workspace_status_msg': _params.workspaceStatusMsg,
+      'agent_id': _params.agentId,
     };
 
     const path = {
       'w_id': _params.wId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'replaceWorkspace');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'replaceWorkspace'
+    );
 
     const parameters = {
       options: {
@@ -628,6 +712,7 @@ class SchematicsV1 extends BaseService {
           {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
+            'X-Github-token': _params.xGithubToken,
           },
           _params.headers
         ),
@@ -643,15 +728,11 @@ class SchematicsV1 extends BaseService {
    * Deletes a workspace from IBM Cloud Schematics. Deleting a workspace does not automatically remove the IBM Cloud
    * resources that the workspace manages. To remove all resources that are associated with the workspace, use the
    * `DELETE /v1/workspaces/{id}?destroy_resources=true` API.
-   *
    *  **Note**: If you delete a workspace without deleting the resources,
    *  you must manage your resources with the resource dashboard or CLI afterwards.
    *  You cannot use IBM Cloud Schematics anymore to manage your resources.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *  to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -660,7 +741,6 @@ class SchematicsV1 extends BaseService {
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity. The IAM refresh token
    * is required only if you want to destroy the Terraform resources before deleting the Schematics workspace. If you
    * want to delete the workspace only and keep all your Terraform resources, refresh token is not required.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -668,7 +748,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -684,11 +763,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.DeleteWorkspaceParams
   ): Promise<SchematicsV1.Response<string>> {
     const _params = { ...params };
-    const requiredParams = ['refreshToken', 'wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['refreshToken', 'wId'];
+    const _validParams = ['refreshToken', 'wId', 'destroyResources', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -699,7 +778,11 @@ class SchematicsV1 extends BaseService {
       'w_id': _params.wId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteWorkspace');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'deleteWorkspace'
+    );
 
     const parameters = {
       options: {
@@ -728,23 +811,17 @@ class SchematicsV1 extends BaseService {
    * Update workspace metadata.
    *
    * Use this API to update the following workspace metadata:
-   *
    *  * Workspace name (`name`) - **Note**: Updating the workspace name does not update the ID of the workspace.
    *  * Workspace description (`description`)
    *  * Tags (`tags[]`)
    *  * Resource group (`resource_group`)
    *  * Workspace status (`workspace_status.frozen`)
-   *
-   *
    *  **Tip**: If you want to update information about the Terraform template
    *  or IBM Cloud catalog software template that your workspace points to,
    *  use the `PUT /v1/workspaces/{id}` API. To update workspace variables,
    *  use the `PUT /v1/workspaces/{id}/template_data/{template_id}/values` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -754,6 +831,7 @@ class SchematicsV1 extends BaseService {
    * @param {CatalogRef} [params.catalogRef] - Information about the software template that you chose from the IBM Cloud
    * catalog. This information is returned for IBM Cloud catalog offerings only.
    * @param {string} [params.description] - The description of the workspace.
+   * @param {Dependencies} [params.dependencies] - Workspace dependencies.
    * @param {string} [params.name] - The name of the workspace.
    * @param {SharedTargetData} [params.sharedData] - Information about the Target used by the templates originating from
    * the  IBM Cloud catalog offerings. This information is not relevant for workspace created using your own Terraform
@@ -765,6 +843,7 @@ class SchematicsV1 extends BaseService {
    * @param {WorkspaceStatusUpdateRequest} [params.workspaceStatus] - Input to update the workspace status.
    * @param {WorkspaceStatusMessage} [params.workspaceStatusMsg] - Information about the last job that ran against the
    * workspace. -.
+   * @param {string} [params.agentId] - agent id that process workspace jobs.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponse>>}
    */
@@ -772,16 +851,17 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.UpdateWorkspaceParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceResponse>> {
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'catalogRef', 'description', 'dependencies', 'name', 'sharedData', 'tags', 'templateData', 'templateRepo', 'type', 'workspaceStatus', 'workspaceStatusMsg', 'agentId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
       'catalog_ref': _params.catalogRef,
       'description': _params.description,
+      'dependencies': _params.dependencies,
       'name': _params.name,
       'shared_data': _params.sharedData,
       'tags': _params.tags,
@@ -790,13 +870,18 @@ class SchematicsV1 extends BaseService {
       'type': _params.type,
       'workspace_status': _params.workspaceStatus,
       'workspace_status_msg': _params.workspaceStatusMsg,
+      'agent_id': _params.agentId,
     };
 
     const path = {
       'w_id': _params.wId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'updateWorkspace');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'updateWorkspace'
+    );
 
     const parameters = {
       options: {
@@ -835,16 +920,18 @@ class SchematicsV1 extends BaseService {
    * otherwise html.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.TemplateReadme>>}
+   * @deprecated this method is deprecated and may be removed in a future release
    */
   public getWorkspaceReadme(
     params: SchematicsV1.GetWorkspaceReadmeParams
   ): Promise<SchematicsV1.Response<SchematicsV1.TemplateReadme>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: getWorkspaceReadme');
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'ref', 'formatted', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -856,7 +943,11 @@ class SchematicsV1 extends BaseService {
       'w_id': _params.wId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getWorkspaceReadme');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getWorkspaceReadme'
+    );
 
     const parameters = {
       options: {
@@ -885,12 +976,11 @@ class SchematicsV1 extends BaseService {
    *
    * Provide your Terraform template by uploading a TAR file from your local machine. Before you use this API, you must
    * create a workspace without a link to a GitHub or GitLab repository with the `POST /v1/workspaces` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access to the workspace ID and the
-   * resource group. For more information, about Schematics access and permissions, see [Schematics service access roles
-   * and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions,
+   *  see [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.wId - The ID of the workspace where you want to upload your `.tar` file. To find the
@@ -907,11 +997,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.TemplateRepoUploadParams
   ): Promise<SchematicsV1.Response<SchematicsV1.TemplateRepoTarUploadResponse>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'tId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'tId'];
+    const _validParams = ['wId', 'tId', 'file', 'fileContentType', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const formData = {
@@ -926,14 +1016,18 @@ class SchematicsV1 extends BaseService {
       't_id': _params.tId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'templateRepoUpload');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'templateRepoUpload'
+    );
 
     const parameters = {
       options: {
         url: '/v1/workspaces/{w_id}/template_data/{t_id}/template_repo_upload',
         method: 'PUT',
         path,
-        formData,
+        formData
       },
       defaultOptions: extend(true, {}, this.baseOptions, {
         headers: extend(
@@ -955,11 +1049,8 @@ class SchematicsV1 extends BaseService {
    * List workspace input variables.
    *
    * Retrieve a list of input variables that are declared in your Terraform or IBM Cloud catalog template.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -976,11 +1067,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetWorkspaceInputsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.TemplateValues>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'tId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'tId'];
+    const _validParams = ['wId', 'tId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -988,7 +1079,11 @@ class SchematicsV1 extends BaseService {
       't_id': _params.tId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getWorkspaceInputs');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getWorkspaceInputs'
+    );
 
     const parameters = {
       options: {
@@ -1037,11 +1132,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ReplaceWorkspaceInputsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.UserValues>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'tId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'tId'];
+    const _validParams = ['wId', 'tId', 'envValues', 'values', 'variablestore', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -1088,11 +1183,8 @@ class SchematicsV1 extends BaseService {
    * Get workspace template details.
    *
    * Retrieve detailed information about the Terraform template that your workspace points to.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform
-   *  access to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -1107,11 +1199,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetAllWorkspaceInputsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceTemplateValuesResponse>> {
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -1164,11 +1256,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetWorkspaceInputMetadataParams
   ): Promise<SchematicsV1.Response<SchematicsV1.JsonObject[]>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'tId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'tId'];
+    const _validParams = ['wId', 'tId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -1219,11 +1311,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetWorkspaceOutputsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.OutputValuesInner[]>> {
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -1271,11 +1363,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetWorkspaceResourcesParams
   ): Promise<SchematicsV1.Response<SchematicsV1.TemplateResources[]>> {
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -1312,16 +1404,14 @@ class SchematicsV1 extends BaseService {
   /**
    * Get Terraform statefile URL.
    *
+   * This API is deprecated, and is replaced by the `GET /v2/jobs/{job_id}/files`, with `file_type` equal `state_file`.
    * Retrieve the URL to the Terraform statefile (`terraform.tfstate`). You use the URL to access the Terraform
    * statefile. The Terraform statefile includes detailed information about the IBM Cloud resources that you provisioned
    * with IBM Cloud Schematics and Schematics uses the file to determine future create, modify, or delete actions for
    * your resources. To show the content of the Terraform statefile, use the `GET
    * /v1/workspaces/{id}/runtime_data/{template_id}/state_store` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *  to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -1331,23 +1421,29 @@ class SchematicsV1 extends BaseService {
    * find the workspace ID, use the `GET /v1/workspaces` API.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.StateStoreResponseList>>}
+   * @deprecated this method is deprecated and may be removed in a future release
    */
   public getWorkspaceState(
     params: SchematicsV1.GetWorkspaceStateParams
   ): Promise<SchematicsV1.Response<SchematicsV1.StateStoreResponseList>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: getWorkspaceState');
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
       'w_id': _params.wId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getWorkspaceState');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getWorkspaceState'
+    );
 
     const parameters = {
       options: {
@@ -1373,6 +1469,7 @@ class SchematicsV1 extends BaseService {
   /**
    * Show Terraform statefile content.
    *
+   * This API is deprecated, and is replaced by the `GET /v2/jobs/{job_id}/files`, with `file_type` equal `state_file`.
    * Show the content of the Terraform statefile (`terraform.tfstate`) that was created when your Terraform template was
    * applied in IBM Cloud. The statefile holds detailed information about the IBM Cloud resources that were created by
    * IBM Cloud Schematics and Schematics uses the file to determine future create, modify, or delete actions for your
@@ -1385,17 +1482,19 @@ class SchematicsV1 extends BaseService {
    * statefile.  When you create a workspace, the Terraform template that your workspace points to is assigned a unique
    * ID.  To find this ID, use the `GET /v1/workspaces` API and review the template_data.id value.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<SchematicsV1.Response<SchematicsV1.JsonObject[]>>}
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.TemplateStateStore>>}
+   * @deprecated this method is deprecated and may be removed in a future release
    */
   public getWorkspaceTemplateState(
     params: SchematicsV1.GetWorkspaceTemplateStateParams
-  ): Promise<SchematicsV1.Response<SchematicsV1.JsonObject[]>> {
+  ): Promise<SchematicsV1.Response<SchematicsV1.TemplateStateStore>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: getWorkspaceTemplateState');
     const _params = { ...params };
-    const requiredParams = ['wId', 'tId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'tId'];
+    const _validParams = ['wId', 'tId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -1435,11 +1534,8 @@ class SchematicsV1 extends BaseService {
    *
    * Get the Terraform log file URL for a workspace job. You can retrieve the log URL for jobs that were created with
    * the `PUT /v1/workspaces/{id}/apply`, `POST /v1/workspaces/{id}/plan`, or `DELETE /v1/workspaces/{id}/destroy` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *  to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -1451,16 +1547,18 @@ class SchematicsV1 extends BaseService {
    * the job ID, use the `GET /v1/workspaces/{id}/actions` API.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityLogs>>}
+   * @deprecated this method is deprecated and may be removed in a future release
    */
   public getWorkspaceActivityLogs(
     params: SchematicsV1.GetWorkspaceActivityLogsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityLogs>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: getWorkspaceActivityLogs');
     const _params = { ...params };
-    const requiredParams = ['wId', 'activityId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'activityId'];
+    const _validParams = ['wId', 'activityId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -1505,16 +1603,18 @@ class SchematicsV1 extends BaseService {
    * @param {string} params.wId - The ID of the workspace.  To find the workspace ID, use the `GET /v1/workspaces` API.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.LogStoreResponseList>>}
+   * @deprecated this method is deprecated and may be removed in a future release
    */
   public getWorkspaceLogUrls(
     params: SchematicsV1.GetWorkspaceLogUrlsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.LogStoreResponseList>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: getWorkspaceLogUrls');
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -1549,15 +1649,14 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Show logs for the latest action for a workspace template.
+   * Show latest logs for a workspace template.
    *
    * Show the Terraform logs for the most recent job of a template that ran against your workspace.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access to the workspace ID and the
-   * resource group. For more information, about Schematics access and permissions, see [Schematics service access roles
-   * and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions,
+   *  see [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.wId - The ID of the workspace.  To find the workspace ID, use the `GET /v1/workspaces` API.
@@ -1579,11 +1678,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetTemplateLogsParams
   ): Promise<SchematicsV1.Response<string>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'tId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'tId'];
+    const _validParams = ['wId', 'tId', 'logTfCmd', 'logTfPrefix', 'logTfNullResource', 'logTfAnsible', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -1598,7 +1697,11 @@ class SchematicsV1 extends BaseService {
       't_id': _params.tId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getTemplateLogs');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getTemplateLogs'
+    );
 
     const parameters = {
       options: {
@@ -1649,11 +1752,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetTemplateActivityLogParams
   ): Promise<SchematicsV1.Response<string>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'tId', 'activityId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'tId', 'activityId'];
+    const _validParams = ['wId', 'tId', 'activityId', 'logTfCmd', 'logTfPrefix', 'logTfNullResource', 'logTfAnsible', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -1706,14 +1809,11 @@ class SchematicsV1 extends BaseService {
    * Retrieve a list of all Schematics actions that depends on the API endpoint that you have access. For example, if
    * you use an API endpoint for a geography, such as North America, only actions that are created in `us-south` or
    * `us-east` are retrieved.
-   *
    *  For more information, about supported API endpoints, see
    * [API endpoints](/apidocs/schematics#api-endpoints).
-   *
    *  <h3>Authorization</h3>
    *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to an action ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -1722,7 +1822,7 @@ class SchematicsV1 extends BaseService {
    * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
    * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
    * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
-   * 2-6, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
    * `offset` option. Negative numbers are not supported and are ignored.
    * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
    * integer between 1 and 2000. If no value is provided, 100 is used by default.
@@ -1737,6 +1837,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListActionsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.ActionList>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['offset', 'limit', 'sort', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const query = {
       'offset': _params.offset,
@@ -1745,7 +1851,11 @@ class SchematicsV1 extends BaseService {
       'profile': _params.profile,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listActions');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listActions'
+    );
 
     const parameters = {
       options: {
@@ -1776,21 +1886,21 @@ class SchematicsV1 extends BaseService {
    * to execute them. **Note** If your Git repository already contains a host file. Schematics does not overwrite the
    * host file already present in your Git repository. For sample templates, see IBM Cloud Automation
    * [templates](https://github.com/Cloud-Schematics).
-   *
+   *  The Schematics action API now supports bastion host connection with `non-root` user, and bastion connection type
+   * is marked as optional, when inventory connection type is set as [Windows Remote
+   * Management](https://www.ibm.com/docs/en/license-metric-tool?topic=v-configuring-winrm-hyper-hosts)(`winrm`).
    *  For more information, about the Schematics create action,
    *  see [ibmcloud schematics action
    * create](https://cloud.ibm.com/docs/schematics?topic=schematics-schematics-cli-reference#schematics-create-action).
    *  **Note** you cannot update the location and region once an action is created.
    *  Also, make sure your IP addresses are in the
    * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
-   *
    *  <h3>Authorization</h3>
    *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to an action ID and the resource group.
-   *  For more information, about Schematics access and permissions, see
-   *  [Schematics service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions.
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions,
+   *  see [Schematics service access roles and required
+   * permissions](/docs/schematics?topic=schematics-access#action-permissions).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.name] - The unique name of your action. The name can be up to 128 characters long and can
@@ -1799,8 +1909,12 @@ class SchematicsV1 extends BaseService {
    * @param {string} [params.location] - List of locations supported by IBM Cloud Schematics service.  While creating
    * your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the
    * location of the IBM Cloud resources, provisioned using Schematics.
-   * @param {string} [params.resourceGroup] - Resource-group name for an action.  By default, action is created in
-   * default resource group.
+   * @param {string} [params.resourceGroup] - Resource-group name for an action. By default, an action is created in
+   * `Default` resource group.
+   * @param {string} [params.bastionConnectionType] - Type of connection to be used when connecting to bastion host.  If
+   * the `inventory_connection_type=winrm`, then `bastion_connection_type` is not supported.
+   * @param {string} [params.inventoryConnectionType] - Type of connection to be used when connecting to remote host.
+   * **Note** Currently, WinRM supports only Windows system with the public IPs and do not support Bastion host.
    * @param {string[]} [params.tags] - Action tags.
    * @param {UserState} [params.userState] - User defined status of the Schematics object.
    * @param {string} [params.sourceReadmeUrl] - URL of the `README` file, for the source URL.
@@ -1808,10 +1922,10 @@ class SchematicsV1 extends BaseService {
    * @param {string} [params.sourceType] - Type of source for the Template.
    * @param {string} [params.commandParameter] - Schematics job command parameter (playbook-name).
    * @param {string} [params.inventory] - Target inventory record ID, used by the action or ansible playbook.
-   * @param {VariableData[]} [params.credentials] - credentials of the Action.
+   * @param {CredentialVariableData[]} [params.credentials] - credentials of the Action.
    * @param {BastionResourceDefinition} [params.bastion] - Describes a bastion resource.
-   * @param {VariableData} [params.bastionCredential] - User editable variable data & system generated reference to
-   * value.
+   * @param {CredentialVariableData} [params.bastionCredential] - User editable credential variable data and system
+   * generated reference to the value.
    * @param {string} [params.targetsIni] - Inventory of host and host group for the playbook in `INI` file format. For
    * example, `"targets_ini": "[webserverhost]
    *  172.22.192.6
@@ -1821,8 +1935,6 @@ class SchematicsV1 extends BaseService {
    * @param {VariableData[]} [params.inputs] - Input variables for the Action.
    * @param {VariableData[]} [params.outputs] - Output variables for the Action.
    * @param {VariableData[]} [params.settings] - Environment variables for the Action.
-   * @param {ActionState} [params.state] - Computed state of the Action.
-   * @param {SystemLock} [params.sysLock] - System lock status.
    * @param {string} [params.xGithubToken] - The personal access token to authenticate with your private GitHub or
    * GitLab repository and access your Terraform template.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -1832,12 +1944,20 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.CreateActionParams
   ): Promise<SchematicsV1.Response<SchematicsV1.Action>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['name', 'description', 'location', 'resourceGroup', 'bastionConnectionType', 'inventoryConnectionType', 'tags', 'userState', 'sourceReadmeUrl', 'source', 'sourceType', 'commandParameter', 'inventory', 'credentials', 'bastion', 'bastionCredential', 'targetsIni', 'inputs', 'outputs', 'settings', 'xGithubToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const body = {
       'name': _params.name,
       'description': _params.description,
       'location': _params.location,
       'resource_group': _params.resourceGroup,
+      'bastion_connection_type': _params.bastionConnectionType,
+      'inventory_connection_type': _params.inventoryConnectionType,
       'tags': _params.tags,
       'user_state': _params.userState,
       'source_readme_url': _params.sourceReadmeUrl,
@@ -1852,11 +1972,13 @@ class SchematicsV1 extends BaseService {
       'inputs': _params.inputs,
       'outputs': _params.outputs,
       'settings': _params.settings,
-      'state': _params.state,
-      'sys_lock': _params.sysLock,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'createAction');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'createAction'
+    );
 
     const parameters = {
       options: {
@@ -1886,11 +2008,9 @@ class SchematicsV1 extends BaseService {
    *
    * Retrieve the detailed information of an actions from your IBM Cloud account.  This API returns a URL to the log
    * file that you can retrieve by using  the `GET /v2/actions/{action_id}/logs` API.
-   *
    *  <h3>Authorization</h3>
    *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to an action ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
@@ -1906,11 +2026,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetActionParams
   ): Promise<SchematicsV1.Response<SchematicsV1.Action>> {
     const _params = { ...params };
-    const requiredParams = ['actionId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['actionId'];
+    const _validParams = ['actionId', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -1921,7 +2041,11 @@ class SchematicsV1 extends BaseService {
       'action_id': _params.actionId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getAction');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getAction'
+    );
 
     const parameters = {
       options: {
@@ -1953,14 +2077,12 @@ class SchematicsV1 extends BaseService {
    * You can repeat the execution of same job, whenever you patch the actions. For more information, about the
    * Schematics action state, see  [Schematics action state
    * diagram](https://cloud.ibm.com/docs/schematics?topic=schematics-action-setup#action-state-diagram).
-   *
    *  <h3>Authorization</h3>
    *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to an action ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions.
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.actionId - Action Id.  Use GET /actions API to look up the Action Ids in your IBM Cloud
@@ -1968,24 +2090,28 @@ class SchematicsV1 extends BaseService {
    * @param {boolean} [params.force] - Equivalent to -force options in the command line.
    * @param {boolean} [params.propagate] - Auto propagate the chaange or deletion to the dependent resources.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Empty>>}
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>>}
    */
   public deleteAction(
     params: SchematicsV1.DeleteActionParams
-  ): Promise<SchematicsV1.Response<SchematicsV1.Empty>> {
+  ): Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>> {
     const _params = { ...params };
-    const requiredParams = ['actionId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['actionId'];
+    const _validParams = ['actionId', 'force', 'propagate', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
       'action_id': _params.actionId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteAction');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'deleteAction'
+    );
 
     const parameters = {
       options: {
@@ -2016,18 +2142,17 @@ class SchematicsV1 extends BaseService {
    * the normal state for a successful execution.  For more information, about the Schematics action state, see
    * [Schematics action state
    * diagram](https://cloud.ibm.com/docs/schematics?topic=schematics-action-setup#action-state-diagram).
-   *
-   *  **Note** you cannot update the location and region once an action is created.
-   *  Also, make sure your IP addresses are in the
-   * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses].
-   *
+   *  The Schematics action API now supports bastion host connection with `non-root` user, and bastion connection type
+   * is marked as optional, when inventory connection type is set as [Windows Remote
+   * Management](https://www.ibm.com/docs/en/license-metric-tool?topic=v-configuring-winrm-hyper-hosts)(`winrm`).
+   *  **Note** you cannot update the location and region once an action is created. Also, make sure your IP addresses
+   * are in the [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses].
    *  <h3>Authorization</h3>
    *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to an action ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions.
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.actionId - Action Id.  Use GET /actions API to look up the Action Ids in your IBM Cloud
@@ -2038,8 +2163,12 @@ class SchematicsV1 extends BaseService {
    * @param {string} [params.location] - List of locations supported by IBM Cloud Schematics service.  While creating
    * your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the
    * location of the IBM Cloud resources, provisioned using Schematics.
-   * @param {string} [params.resourceGroup] - Resource-group name for an action.  By default, action is created in
-   * default resource group.
+   * @param {string} [params.resourceGroup] - Resource-group name for an action. By default, an action is created in
+   * `Default` resource group.
+   * @param {string} [params.bastionConnectionType] - Type of connection to be used when connecting to bastion host.  If
+   * the `inventory_connection_type=winrm`, then `bastion_connection_type` is not supported.
+   * @param {string} [params.inventoryConnectionType] - Type of connection to be used when connecting to remote host.
+   * **Note** Currently, WinRM supports only Windows system with the public IPs and do not support Bastion host.
    * @param {string[]} [params.tags] - Action tags.
    * @param {UserState} [params.userState] - User defined status of the Schematics object.
    * @param {string} [params.sourceReadmeUrl] - URL of the `README` file, for the source URL.
@@ -2047,10 +2176,10 @@ class SchematicsV1 extends BaseService {
    * @param {string} [params.sourceType] - Type of source for the Template.
    * @param {string} [params.commandParameter] - Schematics job command parameter (playbook-name).
    * @param {string} [params.inventory] - Target inventory record ID, used by the action or ansible playbook.
-   * @param {VariableData[]} [params.credentials] - credentials of the Action.
+   * @param {CredentialVariableData[]} [params.credentials] - credentials of the Action.
    * @param {BastionResourceDefinition} [params.bastion] - Describes a bastion resource.
-   * @param {VariableData} [params.bastionCredential] - User editable variable data & system generated reference to
-   * value.
+   * @param {CredentialVariableData} [params.bastionCredential] - User editable credential variable data and system
+   * generated reference to the value.
    * @param {string} [params.targetsIni] - Inventory of host and host group for the playbook in `INI` file format. For
    * example, `"targets_ini": "[webserverhost]
    *  172.22.192.6
@@ -2060,8 +2189,6 @@ class SchematicsV1 extends BaseService {
    * @param {VariableData[]} [params.inputs] - Input variables for the Action.
    * @param {VariableData[]} [params.outputs] - Output variables for the Action.
    * @param {VariableData[]} [params.settings] - Environment variables for the Action.
-   * @param {ActionState} [params.state] - Computed state of the Action.
-   * @param {SystemLock} [params.sysLock] - System lock status.
    * @param {string} [params.xGithubToken] - The personal access token to authenticate with your private GitHub or
    * GitLab repository and access your Terraform template.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -2071,11 +2198,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.UpdateActionParams
   ): Promise<SchematicsV1.Response<SchematicsV1.Action>> {
     const _params = { ...params };
-    const requiredParams = ['actionId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['actionId'];
+    const _validParams = ['actionId', 'name', 'description', 'location', 'resourceGroup', 'bastionConnectionType', 'inventoryConnectionType', 'tags', 'userState', 'sourceReadmeUrl', 'source', 'sourceType', 'commandParameter', 'inventory', 'credentials', 'bastion', 'bastionCredential', 'targetsIni', 'inputs', 'outputs', 'settings', 'xGithubToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -2083,6 +2210,8 @@ class SchematicsV1 extends BaseService {
       'description': _params.description,
       'location': _params.location,
       'resource_group': _params.resourceGroup,
+      'bastion_connection_type': _params.bastionConnectionType,
+      'inventory_connection_type': _params.inventoryConnectionType,
       'tags': _params.tags,
       'user_state': _params.userState,
       'source_readme_url': _params.sourceReadmeUrl,
@@ -2097,15 +2226,17 @@ class SchematicsV1 extends BaseService {
       'inputs': _params.inputs,
       'outputs': _params.outputs,
       'settings': _params.settings,
-      'state': _params.state,
-      'sys_lock': _params.sysLock,
     };
 
     const path = {
       'action_id': _params.actionId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'updateAction');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'updateAction'
+    );
 
     const parameters = {
       options: {
@@ -2137,10 +2268,12 @@ class SchematicsV1 extends BaseService {
    * Update your template by uploading tape archive file (.tar) file from  your local machine. Before you use this API,
    * you must create an action  without a link to a GitHub or GitLab repository with the `POST /v2/actions` API.
    *
-   * <h3>Authorization</h3>
-   *   Schematics support generic authorization such as service access or  platform access to an action ID and the
-   * resource group.  For more information, about Schematics access and permissions, see  [Schematics service access
-   * roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions.
+   *  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions,
+   *  see [Schematics service access roles and required
+   * permissions](/docs/schematics?topic=schematics-access#action-permissions).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.actionId - Action Id.  Use GET /actions API to look up the Action Ids in your IBM Cloud
@@ -2154,11 +2287,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.UploadTemplateTarActionParams
   ): Promise<SchematicsV1.Response<SchematicsV1.TemplateRepoTarUploadResponse>> {
     const _params = { ...params };
-    const requiredParams = ['actionId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['actionId'];
+    const _validParams = ['actionId', 'file', 'fileContentType', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const formData = {
@@ -2183,7 +2316,7 @@ class SchematicsV1 extends BaseService {
         url: '/v2/actions/{action_id}/template_repo_upload',
         method: 'PUT',
         path,
-        formData,
+        formData
       },
       defaultOptions: extend(true, {}, this.baseOptions, {
         headers: extend(
@@ -2205,7 +2338,7 @@ class SchematicsV1 extends BaseService {
    ************************/
 
   /**
-   * List all workspace jobs.
+   * List workspace jobs.
    *
    * Retrieve a list of all jobs that ran against a workspace. Jobs are generated when you use the `apply`, `plan`,
    * `destroy`, and `refresh`,   command API.
@@ -2215,7 +2348,7 @@ class SchematicsV1 extends BaseService {
    * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
    * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
    * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
-   * 2-6, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
    * `offset` option. Negative numbers are not supported and are ignored.
    * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
    * integer between 1 and 2000. If no value is provided, 100 is used by default.
@@ -2226,11 +2359,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ListWorkspaceActivitiesParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivities>> {
     const _params = { ...params };
-    const requiredParams = ['wId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId'];
+    const _validParams = ['wId', 'offset', 'limit', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -2287,11 +2420,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetWorkspaceActivityParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivity>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'activityId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'activityId'];
+    const _validParams = ['wId', 'activityId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -2329,14 +2462,14 @@ class SchematicsV1 extends BaseService {
   /**
    * Stop the workspace job.
    *
-   * Stop an ongoing schematics job that runs against your workspace.
-   * **Note**: If you remove the Schematics apply job that runs against your workspace,  any changes to your IBM Cloud
-   * resources that are already applied are not reverted.  If a creation, update, or deletion is currently in progress,
-   * Schematics waits for  the job to be completed first. Then, any other resource creations, updates, or  deletions
-   * that are included in your Terraform template file are ignored.
-   * <h3>Authorization</h3>  Schematics supports generic authorization such as service access or platform access  to the
-   * workspace ID and the resource group. For more information, about Schematics  access and permissions, see
-   * [Schematics service access roles and required
+   * Stop an ongoing schematics job that runs against your workspace. **Note**: If you remove the Schematics apply job
+   * that runs against your workspace,  any changes to your IBM Cloud resources that are already applied are not
+   * reverted.  If a creation, update, or deletion is currently in progress, Schematics waits for  the job to be
+   * completed first. Then, any other resource creations, updates, or  deletions that are included in your Terraform
+   * template file are ignored.  <h3>Authorization</h3>
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions,
+   *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
@@ -2350,11 +2483,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.DeleteWorkspaceActivityParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityApplyResult>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'activityId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'activityId'];
+    const _validParams = ['wId', 'activityId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -2393,19 +2526,15 @@ class SchematicsV1 extends BaseService {
    * Run Terraform Commands.
    *
    * Run Terraform state commands to modify the workspace state file, by using the IBM Cloud Schematics API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *  to the workspace ID and the resource group. For more information, about Schematics
-   *  access and permissions,
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.wId - The ID of the workspace.  To find the workspace ID, use the `GET /v1/workspaces` API.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -2413,7 +2542,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -2430,11 +2558,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.RunWorkspaceCommandsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityCommandResult>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'refreshToken'];
+    const _validParams = ['wId', 'refreshToken', 'commands', 'operationName', 'description', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -2486,28 +2614,19 @@ class SchematicsV1 extends BaseService {
    * hours to complete. During this time, you cannot make changes to your workspace. After all updates are applied, the
    * state of the files is [persisted](https://cloud.ibm.com/docs/schematics?topic=schematics-persist-files) to
    * determine what resources exist in your IBM Cloud account.
-   *
-   *
    *  **Important**: Your workspace must be in an `Inactive`, `Active`, `Failed`, or
    *  `Stopped` state to perform a Schematics `apply` job. After all updates are applied,
    *  the state of the files is [persisted](https://cloud.ibm.com/docs/schematics?topic=schematics-persist-files)
    *  to determine what resources exist in your IBM Cloud account.
-   *
-   *
    *  **Note**: This API returns an activity or job ID that you use to retrieve the
    *  log URL with the `GET /v1/workspaces/{id}/actions/{action_id}/logs` API.
-   *
-   *
    *  **Important:** Applying a template might incur costs. Make sure to review
    *  the pricing information for the resources that you specified in your
    *  templates before you apply the template in IBM Cloud.
    *  To find a summary of job that Schematics is about to perform,
    *  create a Terraform execution plan with the `POST /v1/workspaces/{id}/plan` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -2516,7 +2635,6 @@ class SchematicsV1 extends BaseService {
    * @param {string} params.wId - The ID of the workspace for which you want to run a Schematics `apply` job.  To find
    * the workspace ID, use the `GET /workspaces` API.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -2524,7 +2642,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -2539,11 +2656,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ApplyWorkspaceCommandParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityApplyResult>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'refreshToken'];
+    const _validParams = ['wId', 'refreshToken', 'actionOptions', 'delegatedToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -2592,28 +2709,20 @@ class SchematicsV1 extends BaseService {
    * associated with your workspace. Removing your resources does not delete the Schematics workspace. To delete the
    * workspace, use the `DELETE /v1/workspaces/{id}` API. This API returns an activity or job ID that you use to
    * retrieve the URL to the log file with the `GET /v1/workspaces/{id}/actions/{action_id}/logs` API.
-   *
-   *
    *  **Important**: Your workspace must be in an `Active`, `Failed`, or `Stopped` state to perform a Schematics
    * `destroy` job.
-   *
-   *
    *  **Note**: Deleting IBM Cloud resources cannot be undone. Make sure that you back up any required data before you
    * remove your resources.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *   to the workspace ID and the resource group.
-   *   For more information, about Schematics access and permissions,
-   *   see [Schematics service access roles and required
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions,
+   *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.wId - The ID of the workspace for which you want to perform a Schematics `destroy` job.  To
    * find the workspace ID, use the `GET /workspaces` API.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -2621,7 +2730,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -2636,11 +2744,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.DestroyWorkspaceCommandParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityDestroyResult>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'refreshToken'];
+    const _validParams = ['wId', 'refreshToken', 'actionOptions', 'delegatedToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -2689,19 +2797,12 @@ class SchematicsV1 extends BaseService {
    * must be created, modified, or deleted to achieve the state that is described in the Terraform or IBM Cloud catalog
    * template that your workspace points to. During this time, you cannot make changes to your workspace. You can use
    * the summary to verify your changes before you apply the template in IBM Cloud.
-   *
-   *
    *  **Important**: Your workspace must be in an `Inactive`, `Active`, `Failed`, or `Stopped` state to perform a
    * Schematics `plan` job.
-   *
-   *
    *  **Note**: This API returns an activity or job ID that you use to retrieve the URL to the log file with the `GET
    * /v1/workspaces/{id}/actions/{action_id}/logs` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *  to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -2710,7 +2811,6 @@ class SchematicsV1 extends BaseService {
    * @param {string} params.wId - The ID of the workspace, for which you want to run a Schematics `plan` job.  To find
    * the ID of your workspace, use the `GET /v1/workspaces` API.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -2718,11 +2818,11 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
    *   * When the IAM access token is about to expire, use the API key to create a new access token.
+   * @param {WorkspaceActivityOptionsTemplate} [params.actionOptions] - Workspace job options template.
    * @param {string} [params.delegatedToken] - The IAM delegated token for your IBM Cloud account.  This token is
    * required for requests that are sent via the UI only.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
@@ -2732,12 +2832,16 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.PlanWorkspaceCommandParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityPlanResult>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'refreshToken'];
+    const _validParams = ['wId', 'refreshToken', 'actionOptions', 'delegatedToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
+
+    const body = {
+      'action_options': _params.actionOptions,
+    };
 
     const path = {
       'w_id': _params.wId,
@@ -2753,6 +2857,7 @@ class SchematicsV1 extends BaseService {
       options: {
         url: '/v1/workspaces/{w_id}/plan',
         method: 'POST',
+        body,
         path,
       },
       defaultOptions: extend(true, {}, this.baseOptions, {
@@ -2761,6 +2866,7 @@ class SchematicsV1 extends BaseService {
           sdkHeaders,
           {
             'Accept': 'application/json',
+            'Content-Type': 'application/json',
             'refresh_token': _params.refreshToken,
             'delegated_token': _params.delegatedToken,
           },
@@ -2779,11 +2885,8 @@ class SchematicsV1 extends BaseService {
    * account against the state that is stored in the Terraform statefile of your workspace. If differences are found,
    * the Terraform statefile is updated accordingly. This API returns an activity or job ID that you use to retrieve the
    * URL to the log file with the `GET /v1/workspaces/{id}/actions/{action_id}/logs` API.
-   *
    *  <h3>Authorization</h3>
-   *
-   *  Schematics support generic authorization such as service access or platform access
-   *  to the workspace ID and the resource group.
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions,
    *  see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -2792,7 +2895,6 @@ class SchematicsV1 extends BaseService {
    * @param {string} params.wId - The ID of the workspace, for which you want to run a Schematics `refresh` job.  To
    * find the ID of your workspace, use the `GET /v1/workspaces` API.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -2800,7 +2902,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -2814,11 +2915,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.RefreshWorkspaceCommandParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceActivityRefreshResult>> {
     const _params = { ...params };
-    const requiredParams = ['wId', 'refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wId', 'refreshToken'];
+    const _validParams = ['wId', 'refreshToken', 'delegatedToken', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -2860,10 +2961,9 @@ class SchematicsV1 extends BaseService {
    * Retrieve a list of all Schematics jobs.  The job displays a list of jobs with the status as `pending`,
    * `in_progess`,  `success`, or `failed`. Jobs are generated when you use the  `POST /v2/jobs`, `PUT
    * /v2/jobs/{job_id}`, or `DELETE /v2/jobs/{job_id}`.
-   *
    *  <h3>Authorization</h3>
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the job ID and the resource group.
+   *
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -2872,7 +2972,7 @@ class SchematicsV1 extends BaseService {
    * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
    * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
    * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
-   * 2-6, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
    * `offset` option. Negative numbers are not supported and are ignored.
    * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
    * integer between 1 and 2000. If no value is provided, 100 is used by default.
@@ -2880,9 +2980,10 @@ class SchematicsV1 extends BaseService {
    * sub-fields (eg. owner.last_name). Prepend the field with '+' or '-', indicating 'ascending' or 'descending'
    * (default is ascending)   Ignore unrecognized or unsupported sort field.
    * @param {string} [params.profile] - Level of details returned by the get method.
-   * @param {string} [params.resource] - Name of the resource (workspace, actions or controls).
+   * @param {string} [params.resource] - Name of the resource (workspaces, actions, environment or controls).
    * @param {string} [params.resourceId] - The Resource Id. It could be an Action-id or Workspace-id.
    * @param {string} [params.actionId] - Action Id.
+   * @param {string} [params.workspaceId] - Workspace Id.
    * @param {string} [params.list] - list jobs.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.JobList>>}
@@ -2891,6 +2992,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListJobsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.JobList>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['offset', 'limit', 'sort', 'profile', 'resource', 'resourceId', 'actionId', 'workspaceId', 'list', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const query = {
       'offset': _params.offset,
@@ -2900,10 +3007,15 @@ class SchematicsV1 extends BaseService {
       'resource': _params.resource,
       'resource_id': _params.resourceId,
       'action_id': _params.actionId,
+      'workspace_id': _params.workspaceId,
       'list': _params.list,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listJobs');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listJobs'
+    );
 
     const parameters = {
       options: {
@@ -2934,7 +3046,6 @@ class SchematicsV1 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -2942,7 +3053,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -2960,9 +3070,12 @@ class SchematicsV1 extends BaseService {
    * your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the
    * location of the IBM Cloud resources, provisioned using Schematics.
    * @param {JobStatus} [params.status] - Job Status.
+   * @param {CartOrderData[]} [params.cartOrderData] - Contains the cart order data which can be used for different
+   * purpose for eg. service tagging.
    * @param {JobData} [params.data] - Job data.
    * @param {BastionResourceDefinition} [params.bastion] - Describes a bastion resource.
    * @param {JobLogSummary} [params.logSummary] - Job log summary record.
+   * @param {AgentInfo} [params.agent] - Agent name, Agent id and associated policy ID information.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.Job>>}
    */
@@ -2970,11 +3083,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.CreateJobParams
   ): Promise<SchematicsV1.Response<SchematicsV1.Job>> {
     const _params = { ...params };
-    const requiredParams = ['refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['refreshToken'];
+    const _validParams = ['refreshToken', 'commandObject', 'commandObjectId', 'commandName', 'commandParameter', 'commandOptions', 'inputs', 'settings', 'tags', 'location', 'status', 'cartOrderData', 'data', 'bastion', 'logSummary', 'agent', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -2988,12 +3101,18 @@ class SchematicsV1 extends BaseService {
       'tags': _params.tags,
       'location': _params.location,
       'status': _params.status,
+      'cart_order_data': _params.cartOrderData,
       'data': _params.data,
       'bastion': _params.bastion,
       'log_summary': _params.logSummary,
+      'agent': _params.agent,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'createJob');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'createJob'
+    );
 
     const parameters = {
       options: {
@@ -3022,10 +3141,9 @@ class SchematicsV1 extends BaseService {
    * Get a job.
    *
    * Retrieve the detailed information of Job
-   *
    *  <h3>Authorization</h3>
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the job ID and the resource group.
+   *
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -3040,11 +3158,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetJobParams
   ): Promise<SchematicsV1.Response<SchematicsV1.Job>> {
     const _params = { ...params };
-    const requiredParams = ['jobId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['jobId'];
+    const _validParams = ['jobId', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -3055,7 +3173,11 @@ class SchematicsV1 extends BaseService {
       'job_id': _params.jobId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getJob');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getJob'
+    );
 
     const parameters = {
       options: {
@@ -3084,10 +3206,9 @@ class SchematicsV1 extends BaseService {
    *
    * Creates a copy of the Schematics job and relaunches an existing job  by updating the information of an existing
    * Schematics job.
-   *
    *  <h3>Authorization</h3>
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the job ID and the resource group.
+   *
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -3095,7 +3216,6 @@ class SchematicsV1 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.jobId - Job Id. Use `GET /v2/jobs` API to look up the Job Ids in your IBM Cloud account.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -3103,7 +3223,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -3121,9 +3240,12 @@ class SchematicsV1 extends BaseService {
    * your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the
    * location of the IBM Cloud resources, provisioned using Schematics.
    * @param {JobStatus} [params.status] - Job Status.
+   * @param {CartOrderData[]} [params.cartOrderData] - Contains the cart order data which can be used for different
+   * purpose for eg. service tagging.
    * @param {JobData} [params.data] - Job data.
    * @param {BastionResourceDefinition} [params.bastion] - Describes a bastion resource.
    * @param {JobLogSummary} [params.logSummary] - Job log summary record.
+   * @param {AgentInfo} [params.agent] - Agent name, Agent id and associated policy ID information.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.Job>>}
    */
@@ -3131,11 +3253,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.UpdateJobParams
   ): Promise<SchematicsV1.Response<SchematicsV1.Job>> {
     const _params = { ...params };
-    const requiredParams = ['jobId', 'refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['jobId', 'refreshToken'];
+    const _validParams = ['jobId', 'refreshToken', 'commandObject', 'commandObjectId', 'commandName', 'commandParameter', 'commandOptions', 'inputs', 'settings', 'tags', 'location', 'status', 'cartOrderData', 'data', 'bastion', 'logSummary', 'agent', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -3149,16 +3271,22 @@ class SchematicsV1 extends BaseService {
       'tags': _params.tags,
       'location': _params.location,
       'status': _params.status,
+      'cart_order_data': _params.cartOrderData,
       'data': _params.data,
       'bastion': _params.bastion,
       'log_summary': _params.logSummary,
+      'agent': _params.agent,
     };
 
     const path = {
       'job_id': _params.jobId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'updateJob');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'updateJob'
+    );
 
     const parameters = {
       options: {
@@ -3190,10 +3318,9 @@ class SchematicsV1 extends BaseService {
    * Stop the running Job, and delete the Job.  **Note** You cannot delete or stop the job activity from an ongoing
    * execution of an action defined in the playbook.  You can repeat the execution of same job, whenever you patch or
    * update the action or workspace.
-   *
    *  <h3>Authorization</h3>
-   *  Schematics support generic authorization such as service access or
-   *  platform access to the job ID and the resource group.
+   *
+   *  Schematics support generic authorization for its resources.
    *  For more information, about Schematics access and permissions, see
    *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
@@ -3201,7 +3328,6 @@ class SchematicsV1 extends BaseService {
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.jobId - Job Id. Use `GET /v2/jobs` API to look up the Job Ids in your IBM Cloud account.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -3209,7 +3335,6 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -3217,24 +3342,28 @@ class SchematicsV1 extends BaseService {
    * @param {boolean} [params.force] - Equivalent to -force options in the command line.
    * @param {boolean} [params.propagate] - Auto propagate the chaange or deletion to the dependent resources.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Empty>>}
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>>}
    */
   public deleteJob(
     params: SchematicsV1.DeleteJobParams
-  ): Promise<SchematicsV1.Response<SchematicsV1.Empty>> {
+  ): Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>> {
     const _params = { ...params };
-    const requiredParams = ['jobId', 'refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['jobId', 'refreshToken'];
+    const _validParams = ['jobId', 'refreshToken', 'force', 'propagate', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
       'job_id': _params.jobId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteJob');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'deleteJob'
+    );
 
     const parameters = {
       options: {
@@ -3262,10 +3391,8 @@ class SchematicsV1 extends BaseService {
   /**
    * Get job logs.
    *
-   * Retrieve the job logs
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or  platform access to the
-   * action ID and the resource group.  For more information, about Schematics access and permissions, see  [Schematics
-   * service access roles and required
+   * Retrieve the job logs <h3>Authorization</h3> Schematics support generic authorization for its resources. For more
+   * information, about Schematics access and permissions, see [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
@@ -3277,18 +3404,22 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ListJobLogsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.JobLog>> {
     const _params = { ...params };
-    const requiredParams = ['jobId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['jobId'];
+    const _validParams = ['jobId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
       'job_id': _params.jobId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listJobLogs');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listJobLogs'
+    );
 
     const parameters = {
       options: {
@@ -3310,19 +3441,84 @@ class SchematicsV1 extends BaseService {
 
     return this.createRequest(parameters);
   }
+
+  /**
+   * Get output files from the Job record.
+   *
+   * Get output files from the Job record. For more information, about the Schematics job status, download job logs, and
+   * download the output files, see [Download Schematics
+   * Job](https://cloud.ibm.com/docs/schematics?topic=schematics-job-download).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.jobId - Job Id. Use `GET /v2/jobs` API to look up the Job Ids in your IBM Cloud account.
+   * @param {string} params.fileType - The type of file you want to download eg.state_file, plan_json.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.JobFileData>>}
+   */
+  public getJobFiles(
+    params: SchematicsV1.GetJobFilesParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.JobFileData>> {
+    const _params = { ...params };
+    const _requiredParams = ['jobId', 'fileType'];
+    const _validParams = ['jobId', 'fileType', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'file_type': _params.fileType,
+    };
+
+    const path = {
+      'job_id': _params.jobId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getJobFiles'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/jobs/{job_id}/files',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
   /*************************
    * bulkJobs
    ************************/
 
   /**
-   * Delete multiple workspaces.
+   * Delete one or more workspace.
    *
-   * Delete multiple workspaces.  Use ?destroy_resource="true" to destroy the related cloud resources,  otherwise the
-   * resources must be managed outside of Schematics.
+   * Delete one or multiple Schematics workspace. Deleting a workspace does not destroy the resources from the
+   * Schematics workspace.
+   *    <h3>Authorization</h3>
+   *
+   *    Schematics support generic authorization for its resources.
+   *    For more information, about Schematics access and permissions, see
+   *    [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.refreshToken - The IAM refresh token for the user or service identity.
-   *
    *   **Retrieving refresh token**:
    *   * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
    * "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -3330,19 +3526,13 @@ class SchematicsV1 extends BaseService {
    *   * For more information, about creating IAM access token and API Docs, refer, [IAM access
    * token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
    * key](/apidocs/iam-identity-token-api#create-api-key).
-   *
    *   **Limitation**:
    *   * If the token is expired, you can use `refresh token` to get a new IAM access token.
    *   * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
    *   * When the IAM access token is about to expire, use the API key to create a new access token.
-   * @param {boolean} [params.newDeleteWorkspaces] - True to delete workspace.
-   * @param {boolean} [params.newDestroyResources] - True to destroy the resources managed by this workspace.
-   * @param {string} [params.newJob] - Workspace deletion job name.
-   * @param {string} [params.newVersion] - Version of the terraform template.
-   * @param {string[]} [params.newWorkspaces] - List of workspaces to be deleted.
-   * @param {string} [params.destroyResources] - If set to `true`, refresh_token header configuration is required to
-   * delete all the Terraform resources, and the Schematics workspace. If set to `false`, you can remove only the
-   * workspace. Your Terraform resources are still available and must be managed with the resource dashboard or CLI.
+   * @param {string} [params.job] - Job type such as delete of a batch operation.
+   * @param {string} [params.version] - A version of the terraform template.
+   * @param {string[]} [params.workspaces] - The List of workspaces to be deleted.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.WorkspaceBulkDeleteResponse>>}
    */
@@ -3350,23 +3540,17 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.CreateWorkspaceDeletionJobParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceBulkDeleteResponse>> {
     const _params = { ...params };
-    const requiredParams = ['refreshToken'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['refreshToken'];
+    const _validParams = ['refreshToken', 'job', 'version', 'workspaces', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
-      'delete_workspaces': _params.newDeleteWorkspaces,
-      'destroy_resources': _params.newDestroyResources,
-      'job': _params.newJob,
-      'version': _params.newVersion,
-      'workspaces': _params.newWorkspaces,
-    };
-
-    const query = {
-      'destroy_resources': _params.destroyResources,
+      'job': _params.job,
+      'version': _params.version,
+      'workspaces': _params.workspaces,
     };
 
     const sdkHeaders = getSdkHeaders(
@@ -3380,7 +3564,6 @@ class SchematicsV1 extends BaseService {
         url: '/v1/workspace_jobs',
         method: 'POST',
         body,
-        qs: query,
       },
       defaultOptions: extend(true, {}, this.baseOptions, {
         headers: extend(
@@ -3402,7 +3585,13 @@ class SchematicsV1 extends BaseService {
   /**
    * Get the workspace deletion job status.
    *
-   * Get the workspace deletion job status.
+   * Retrieve detailed information for a workspace deletion job status.
+   *    <h3>Authorization</h3>
+   *
+   *    Schematics support generic authorization for its resources.
+   *    For more information, about Schematics access and permissions, see
+   *    [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.wjId - The workspace job ID.
@@ -3413,11 +3602,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetWorkspaceDeletionJobStatusParams
   ): Promise<SchematicsV1.Response<SchematicsV1.WorkspaceJobResponse>> {
     const _params = { ...params };
-    const requiredParams = ['wjId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['wjId'];
+    const _validParams = ['wjId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -3451,26 +3640,488 @@ class SchematicsV1 extends BaseService {
     return this.createRequest(parameters);
   }
   /*************************
-   * inventory
+   * blueprint
    ************************/
 
   /**
-   * List all inventory definitions.
+   * List blueprint.
    *
-   * Retrieve a list of all Schematics inventories that depends on the API endpoint that you have access. For example,
-   * if you use an API endpoint for a geography, such as North America, only inventories that are created in `us-south`
-   * or `us-east` are retrieved. For more information, about supported API endpoints, see
-   * [APIendpoints](/apidocs/schematics#api-endpoints).
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions, see  [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   * Retrieve a list of Schematics Blueprints from your IBM Cloud account that you have access to. The list of
+   * blueprints that is returned depends on the API endpoint that you use. For example, if you use an API endpoint for a
+   * geography, such as North America, only blueprints that are created in us-south or us-east are returned. </b> </b>
+   * For more information about supported API endpoints, see [API
+   * endpoints](https://cloud.ibm.com/apidocs/schematics/schematics#api-endpoints).
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions, see [Schematics service access
+   *   roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
    * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
    * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
-   * 2-6, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `offset` option. Negative numbers are not supported and are ignored.
+   * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
+   * integer between 1 and 2000. If no value is provided, 100 is used by default.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.BlueprintList>>}
+   */
+  public listBlueprint(
+    params?: SchematicsV1.ListBlueprintParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.BlueprintList>> {
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['offset', 'limit', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'offset': _params.offset,
+      'limit': _params.limit,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listBlueprint'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/blueprints',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a blueprint.
+   *
+   * Deploying an IBM Cloud Schematics Blueprint environment and cloud resources by using a blueprint template is a
+   * two-step process. The first step is create a blueprint configuration in Schematics, the second step deploys the
+   * configuration by using blueprint apply operation. </br></br> Create an IBM Cloud Schematics Blueprint that points
+   * to the blueprint configuration where your blueprint template are stored. The blueprint config specifies the Git
+   * source and release of the blueprint template, input files, and any input values that are used to create cloud
+   * resources. Blueprint creates a blueprint module resource in Schematics for each module definition in the template.
+   * Blueprint module resources are initialized with the Terraform module source from the Git repository specified in
+   * the module definition, and module inputs. </br></br>Blueprint apply create, or update resources in a blueprint
+   * environment. For more information about apply blueprint configuration changes to an environment, see [blueprint
+   * apply](https://cloud.ibm.com/docs/schematics?topic=schematics-apply-blueprint&interface=api).
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions, see [Schematics service access
+   *   roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.name - Blueprint name (unique for an account).
+   * @param {string} [params.schemaVersion] - Schema version.
+   * @param {ExternalSource} [params.source] - Source of templates, playbooks, or controls.
+   * @param {BlueprintConfigItem[]} [params.config] - Blueprint input configuration definition.
+   * @param {string} [params.description] - Blueprint description.
+   * @param {string} [params.resourceGroup] - Resource-group name for the blueprint.  By default, blueprint will be
+   * created in Default Resource Group.
+   * @param {string[]} [params.tags] - Blueprint instance tags.
+   * @param {string} [params.location] - List of locations supported by IBM Cloud Schematics service.  While creating
+   * your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the
+   * location of the IBM Cloud resources, provisioned using Schematics.
+   * @param {VariableData[]} [params.inputs] - Additional inputs configuration for the blueprint.
+   * @param {VariableData[]} [params.settings] - Input environemnt settings for blueprint.
+   * @param {BlueprintFlow} [params.flow] - Flow definitions for all the blueprint command.
+   * @param {UserState} [params.userState] - User defined status of the Schematics object.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Blueprint>>}
+   */
+  public createBlueprint(
+    params: SchematicsV1.CreateBlueprintParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.Blueprint>> {
+    const _params = { ...params };
+    const _requiredParams = ['name'];
+    const _validParams = ['name', 'schemaVersion', 'source', 'config', 'description', 'resourceGroup', 'tags', 'location', 'inputs', 'settings', 'flow', 'userState', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+      'schema_version': _params.schemaVersion,
+      'source': _params.source,
+      'config': _params.config,
+      'description': _params.description,
+      'resource_group': _params.resourceGroup,
+      'tags': _params.tags,
+      'location': _params.location,
+      'inputs': _params.inputs,
+      'settings': _params.settings,
+      'flow': _params.flow,
+      'user_state': _params.userState,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'createBlueprint'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/blueprints',
+        method: 'POST',
+        body,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Get a blueprint.
+   *
+   * Retrieve detailed information for a blueprint in your IBM Cloud account. For more information about displaying
+   * blueprint example, see [displaying
+   * blueprint](https://cloud.ibm.com/docs/schematics?topic=schematics-list-blueprint&interface=api).
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions, see [Schematics service access
+   *   roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.blueprintId - Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your
+   * IBM Cloud account.
+   * @param {string} [params.profile] - Level of details returned by the get method.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Blueprint>>}
+   */
+  public getBlueprint(
+    params: SchematicsV1.GetBlueprintParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.Blueprint>> {
+    const _params = { ...params };
+    const _requiredParams = ['blueprintId'];
+    const _validParams = ['blueprintId', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'profile': _params.profile,
+    };
+
+    const path = {
+      'blueprint_id': _params.blueprintId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getBlueprint'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/blueprints/{blueprint_id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update a blueprint.
+   *
+   * Use this API to update or replace the entire blueprint, including the blueprint configuration or module resources
+   * that your blueprint points to. For more information about update blueprint example, see [Update blueprint
+   * configuration](https://cloud.ibm.com/docs/schematics?topic=schematics-update-blueprint&interface=api).
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions, see [Schematics service access
+   *   roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.blueprintId - Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your
+   * IBM Cloud account.
+   * @param {string} params.name - Blueprint name (unique for an account).
+   * @param {string} [params.schemaVersion] - Schema version.
+   * @param {ExternalSource} [params.source] - Source of templates, playbooks, or controls.
+   * @param {BlueprintConfigItem[]} [params.config] - Blueprint input configuration definition.
+   * @param {string} [params.description] - Blueprint description.
+   * @param {string} [params.resourceGroup] - Resource-group name for the blueprint.  By default, blueprint will be
+   * created in Default Resource Group.
+   * @param {string[]} [params.tags] - Blueprint instance tags.
+   * @param {string} [params.location] - List of locations supported by IBM Cloud Schematics service.  While creating
+   * your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the
+   * location of the IBM Cloud resources, provisioned using Schematics.
+   * @param {VariableData[]} [params.inputs] - Additional inputs configuration for the blueprint.
+   * @param {VariableData[]} [params.settings] - Input environemnt settings for blueprint.
+   * @param {BlueprintFlow} [params.flow] - Flow definitions for all the blueprint command.
+   * @param {UserState} [params.userState] - User defined status of the Schematics object.
+   * @param {string} [params.profile] - Level of details returned by the get method.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Blueprint>>}
+   */
+  public replaceBlueprint(
+    params: SchematicsV1.ReplaceBlueprintParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.Blueprint>> {
+    const _params = { ...params };
+    const _requiredParams = ['blueprintId', 'name'];
+    const _validParams = ['blueprintId', 'name', 'schemaVersion', 'source', 'config', 'description', 'resourceGroup', 'tags', 'location', 'inputs', 'settings', 'flow', 'userState', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+      'schema_version': _params.schemaVersion,
+      'source': _params.source,
+      'config': _params.config,
+      'description': _params.description,
+      'resource_group': _params.resourceGroup,
+      'tags': _params.tags,
+      'location': _params.location,
+      'inputs': _params.inputs,
+      'settings': _params.settings,
+      'flow': _params.flow,
+      'user_state': _params.userState,
+    };
+
+    const query = {
+      'profile': _params.profile,
+    };
+
+    const path = {
+      'blueprint_id': _params.blueprintId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'replaceBlueprint'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/blueprints/{blueprint_id}',
+        method: 'PUT',
+        body,
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Delete a blueprint.
+   *
+   * Deleting a blueprint environment is a two stage process that first destroys all the associated cloud resources and
+   * second deletes the blueprint configuration in IBM Cloud Schematics. </br> </br>For more information about destroy
+   * blueprint and delete blueprint, see [destroying blueprint
+   * environment](https://cloud.ibm.com/docs/schematics?topic=schematics-destroy-blueprint&interface=api) and [deleting
+   * blueprint configuration](https://cloud.ibm.com/docs/schematics?topic=schematics-delete-blueprint&interface=api).
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions, see [Schematics service access
+   *   roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.blueprintId - Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your
+   * IBM Cloud account.
+   * @param {string} [params.profile] - Level of details returned by the get method.
+   * @param {boolean} [params.destroy] - Destroy the resources before deleting the blueprint.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>>}
+   */
+  public deleteBlueprint(
+    params: SchematicsV1.DeleteBlueprintParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>> {
+    const _params = { ...params };
+    const _requiredParams = ['blueprintId'];
+    const _validParams = ['blueprintId', 'profile', 'destroy', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'profile': _params.profile,
+      'destroy': _params.destroy,
+    };
+
+    const path = {
+      'blueprint_id': _params.blueprintId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'deleteBlueprint'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/blueprints/{blueprint_id}',
+        method: 'DELETE',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Upload a TAR file to a blueprint.
+   *
+   * Update your blueprint configuration by uploading tape archive file (.tar) file from your local machine.
+   *   <h3>Authorization</h3>
+   *   Schematics support generic authorization for its resources.
+   *   For more information, about Schematics access and permissions, see [Schematics service access
+   *   roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.blueprintId - Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your
+   * IBM Cloud account.
+   * @param {NodeJS.ReadableStream | Buffer} [params.file] - Template tar file.
+   * @param {string} [params.fileContentType] - The content type of file.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.BlueprintTemplateRepoTarUploadResponse>>}
+   */
+  public uploadTemplateTarBlueprint(
+    params: SchematicsV1.UploadTemplateTarBlueprintParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.BlueprintTemplateRepoTarUploadResponse>> {
+    const _params = { ...params };
+    const _requiredParams = ['blueprintId'];
+    const _validParams = ['blueprintId', 'file', 'fileContentType', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const formData = {
+      'file': {
+        data: _params.file,
+        contentType: _params.fileContentType,
+      },
+    };
+
+    const path = {
+      'blueprint_id': _params.blueprintId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'uploadTemplateTarBlueprint'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/blueprints/{blueprint_id}/template_repo_upload',
+        method: 'PUT',
+        path,
+        formData
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'multipart/form-data',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+  /*************************
+   * inventory
+   ************************/
+
+  /**
+   * List inventory definitions.
+   *
+   * Retrieve a list of all Schematics inventories that depends on the API endpoint that you have access. For example,
+   * if you use an API endpoint for a geography, such as North America, only inventories that are created in `us-south`
+   * or `us-east` are retrieved. For more information, about supported API endpoints, see
+   * [APIendpoints](/apidocs/schematics#api-endpoints).
+   *  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
+   * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
+   * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
    * `offset` option. Negative numbers are not supported and are ignored.
    * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
    * integer between 1 and 2000. If no value is provided, 100 is used by default.
@@ -3485,6 +4136,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListInventoriesParams
   ): Promise<SchematicsV1.Response<SchematicsV1.InventoryResourceRecordList>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['offset', 'limit', 'sort', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const query = {
       'offset': _params.offset,
@@ -3493,7 +4150,11 @@ class SchematicsV1 extends BaseService {
       'profile': _params.profile,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listInventories');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listInventories'
+    );
 
     const parameters = {
       options: {
@@ -3522,14 +4183,16 @@ class SchematicsV1 extends BaseService {
    * Create an IBM Cloud Schematics inventory as a single IBM Cloud resource where you want to run Ansible playbook by
    * using Schematics actions. For more information, about inventory host groups, refer to [creating static and dynamic
    * inventory for Schematics actions](https://cloud.ibm.com/docs/schematics?topic=schematics-inventories-setup).
-   * **Note** you cannot update the location and region, resource group once an action is created.  Also, make sure your
+   *  **Note** you cannot update the location and region, resource group once an action is created. Also, make sure your
    * IP addresses are in the [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
-   * If your Git repository already contains a host file. Schematics does not  overwrite the host file already present
+   *  If your Git repository already contains a host file. Schematics does not overwrite the host file already present
    * in your Git repository.
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions, see  [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   *  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.name] - The unique name of your Inventory definition. The name can be up to 128 characters
@@ -3552,6 +4215,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.CreateInventoryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.InventoryResourceRecord>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['name', 'description', 'location', 'resourceGroup', 'inventoriesIni', 'resourceQueries', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const body = {
       'name': _params.name,
@@ -3562,7 +4231,11 @@ class SchematicsV1 extends BaseService {
       'resource_queries': _params.resourceQueries,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'createInventory');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'createInventory'
+    );
 
     const parameters = {
       options: {
@@ -3587,23 +4260,26 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Get the inventory definition.
+   * Get an inventory definition.
    *
    * Use this API to retrieve the detailed information for a resource inventory definition used to target an action in
    * your IBM Cloud account. For more information, about inventory get, refer to [ibmcloud schematics inventory
    * get](https://cloud.ibm.com/docs/schematics?topic=schematics-schematics-cli-reference#schematics-get-inv).
+   *
    *  **Note** you can fetch only the location and region, resource group from where your inventory is created.
    *  Also, make sure your IP addresses are in the
    * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
+   *  <h3>Authorization</h3>
    *
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions, see [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.inventoryId - Resource Inventory Id.  Use `GET /v2/inventories` API to look up the Resource
    * Inventory definition Ids  in your IBM Cloud account.
+   * @param {string} [params.profile] - Level of details returned by the get method.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.InventoryResourceRecord>>}
    */
@@ -3611,23 +4287,32 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetInventoryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.InventoryResourceRecord>> {
     const _params = { ...params };
-    const requiredParams = ['inventoryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['inventoryId'];
+    const _validParams = ['inventoryId', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
+
+    const query = {
+      'profile': _params.profile,
+    };
 
     const path = {
       'inventory_id': _params.inventoryId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getInventory');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getInventory'
+    );
 
     const parameters = {
       options: {
         url: '/v2/inventories/{inventory_id}',
         method: 'GET',
+        qs: query,
         path,
       },
       defaultOptions: extend(true, {}, this.baseOptions, {
@@ -3646,19 +4331,22 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Replace an inventory definition.
+   * Update an inventory definition.
    *
    * Use this API to update the inventory definition resource used to target an action. For more information, about
    * inventory update, refer to [ibmcloud schematics inventory
    * update](https://cloud.ibm.com/docs/schematics?topic=schematics-schematics-cli-reference#schematics-update-inv).
+   *
    *  **Note** you cannot update the location and region, resource group once an action is created.
    *  Also, make sure your IP addresses are in the
    * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
    *
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions, see  [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   *  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.inventoryId - Resource Inventory Id.  Use `GET /v2/inventories` API to look up the Resource
@@ -3683,11 +4371,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ReplaceInventoryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.InventoryResourceRecord>> {
     const _params = { ...params };
-    const requiredParams = ['inventoryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['inventoryId'];
+    const _validParams = ['inventoryId', 'name', 'description', 'location', 'resourceGroup', 'inventoriesIni', 'resourceQueries', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -3703,7 +4391,11 @@ class SchematicsV1 extends BaseService {
       'inventory_id': _params.inventoryId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'replaceInventory');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'replaceInventory'
+    );
 
     const parameters = {
       options: {
@@ -3729,19 +4421,21 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Delete inventory definition.
+   * Delete an inventory definition.
    *
    * Use this API to delete the resource inventory definition by using the inventory ID that you want to run against.
    * For more information, about inventory delete, refer to [ibmcloud schematics inventory
    * delete](https://cloud.ibm.com/docs/schematics?topic=schematics-schematics-cli-reference#schematics-delete-inventory).
-   *  **Note** you cannot delete the location and region, resource group from where your inventory is created.
-   *  Also, make sure your IP addresses are in the
-   * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
    *
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions, see  [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   *  **Note** you cannot delete the location and region, resource group from where your inventory is created. Also,
+   * make sure your IP addresses are in the
+   * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
+   *  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.inventoryId - Resource Inventory Id.  Use `GET /v2/inventories` API to look up the Resource
@@ -3749,24 +4443,28 @@ class SchematicsV1 extends BaseService {
    * @param {boolean} [params.force] - Equivalent to -force options in the command line.
    * @param {boolean} [params.propagate] - Auto propagate the chaange or deletion to the dependent resources.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Empty>>}
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>>}
    */
   public deleteInventory(
     params: SchematicsV1.DeleteInventoryParams
-  ): Promise<SchematicsV1.Response<SchematicsV1.Empty>> {
+  ): Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>> {
     const _params = { ...params };
-    const requiredParams = ['inventoryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['inventoryId'];
+    const _validParams = ['inventoryId', 'force', 'propagate', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
       'inventory_id': _params.inventoryId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'deleteInventory');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'deleteInventory'
+    );
 
     const parameters = {
       options: {
@@ -3791,98 +4489,24 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Update the inventory definition.
-   *
-   * Update the resource inventory definition.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.inventoryId - Resource Inventory Id.  Use `GET /v2/inventories` API to look up the Resource
-   * Inventory definition Ids  in your IBM Cloud account.
-   * @param {string} [params.name] - The unique name of your Inventory definition. The name can be up to 128 characters
-   * long and can include alphanumeric characters, spaces, dashes, and underscores.
-   * @param {string} [params.description] - The description of your Inventory definition. The description can be up to
-   * 2048 characters long in size.
-   * @param {string} [params.location] - List of locations supported by IBM Cloud Schematics service.  While creating
-   * your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the
-   * location of the IBM Cloud resources, provisioned using Schematics.
-   * @param {string} [params.resourceGroup] - Resource-group name for the Inventory definition.   By default, Inventory
-   * definition will be created in Default Resource Group.
-   * @param {string} [params.inventoriesIni] - Input inventory of host and host group for the playbook, in the `.ini`
-   * file format.
-   * @param {string[]} [params.resourceQueries] - Input resource query definitions that is used to dynamically generate
-   * the inventory of host and host group for the playbook.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<SchematicsV1.Response<SchematicsV1.InventoryResourceRecord>>}
-   */
-  public updateInventory(
-    params: SchematicsV1.UpdateInventoryParams
-  ): Promise<SchematicsV1.Response<SchematicsV1.InventoryResourceRecord>> {
-    const _params = { ...params };
-    const requiredParams = ['inventoryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
-    }
-
-    const body = {
-      'name': _params.name,
-      'description': _params.description,
-      'location': _params.location,
-      'resource_group': _params.resourceGroup,
-      'inventories_ini': _params.inventoriesIni,
-      'resource_queries': _params.resourceQueries,
-    };
-
-    const path = {
-      'inventory_id': _params.inventoryId,
-    };
-
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'updateInventory');
-
-    const parameters = {
-      options: {
-        url: '/v2/inventories/{inventory_id}',
-        method: 'PATCH',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-  /*************************
-   * resourceQuery
-   ************************/
-
-  /**
    * List resource queries.
    *
    * Retrieve the list of resource query definitions that you have access to.  The list of resource queries that is
    * returned depends on the API  endpoint that you use. For example, if you use an API endpoint for a geography, such
    * as North America, only resource query definitions that are created in `us-south` or `us-east` are retrieved. For
    * more information, about supported API endpoints, see [API endpoints](/apidocs/schematics#api-endpoints).
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions,  see [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   * <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
    * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
    * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
-   * 2-6, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
    * `offset` option. Negative numbers are not supported and are ignored.
    * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
    * integer between 1 and 2000. If no value is provided, 100 is used by default.
@@ -3897,6 +4521,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.ListResourceQueryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.ResourceQueryRecordList>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['offset', 'limit', 'sort', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const query = {
       'offset': _params.offset,
@@ -3905,7 +4535,11 @@ class SchematicsV1 extends BaseService {
       'profile': _params.profile,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listResourceQuery');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listResourceQuery'
+    );
 
     const parameters = {
       options: {
@@ -3938,11 +4572,12 @@ class SchematicsV1 extends BaseService {
    * **Note** you cannot update the location and region, resource group  once an action is created. Also, make sure your
    * IP addresses are  in the [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
    * If your Git repository already contains a host file.  Schematics does not overwrite the host file already present
-   * in your Git repository.
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions,  see [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   * in your Git repository. <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {string} [params.type] - Resource type (cluster, vsi, icd, vpc).
@@ -3955,6 +4590,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.CreateResourceQueryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.ResourceQueryRecord>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['type', 'name', 'queries', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const body = {
       'type': _params.type,
@@ -3996,10 +4637,12 @@ class SchematicsV1 extends BaseService {
    * Use this API to retrieve the information resource query by Id.  For more information, about resource query
    * commands, refer to  [ibmcloud schematics resource query
    * get](https://cloud.ibm.com/docs/schematics?topic=schematics-schematics-cli-reference#schematics-get-rq).
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions,  see [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   * <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.queryId - Resource query Id.  Use `GET /v2/resource_query` API to look up the Resource query
@@ -4011,18 +4654,22 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetResourcesQueryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.ResourceQueryRecord>> {
     const _params = { ...params };
-    const requiredParams = ['queryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['queryId'];
+    const _validParams = ['queryId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
       'query_id': _params.queryId,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getResourcesQuery');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getResourcesQuery'
+    );
 
     const parameters = {
       options: {
@@ -4046,18 +4693,19 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Replace resources query definition.
+   * Update resources query definition.
    *
-   * Use this API to replace the resource query definition used to build  the dynamic inventory for the Schematics
+   * Use this API to update the resource query definition used to build  the dynamic inventory for the Schematics
    * Action.  For more information, about resource query commands, refer to [ibmcloud schematics resource query
    * update](https://cloud.ibm.com/docs/schematics?topic=schematics-schematics-cli-reference#schematics-update-rq).
    * **Note** you cannot update the location and region, resource group  once a resource query is created. Also, make
    * sure your IP addresses  are in the
-   * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions,  see [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   * [allowlist](https://cloud.ibm.com/docs/schematics?topic=schematics-allowed-ipaddresses).  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.queryId - Resource query Id.  Use `GET /v2/resource_query` API to look up the Resource query
@@ -4072,11 +4720,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ReplaceResourcesQueryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.ResourceQueryRecord>> {
     const _params = { ...params };
-    const requiredParams = ['queryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['queryId'];
+    const _validParams = ['queryId', 'type', 'name', 'queries', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const body = {
@@ -4133,11 +4781,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ExecuteResourceQueryParams
   ): Promise<SchematicsV1.Response<SchematicsV1.ResourceQueryResponseRecord>> {
     const _params = { ...params };
-    const requiredParams = ['queryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['queryId'];
+    const _validParams = ['queryId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -4177,11 +4825,12 @@ class SchematicsV1 extends BaseService {
    * Use this API to delete the resource query definition by Id.  For more information, about resource query commands,
    * refer to  [ibmcloud schematics resource query
    * delete](https://cloud.ibm.com/docs/schematics?topic=schematics-schematics-cli-reference#schematics-delete-resource-query).
+   *  <h3>Authorization</h3>
    *
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to an
-   * action ID and the resource group. For more information, about Schematics access and permissions,  see [Schematics
-   * service access roles and required
-   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#action-permissions).
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.queryId - Resource query Id.  Use `GET /v2/resource_query` API to look up the Resource query
@@ -4189,17 +4838,17 @@ class SchematicsV1 extends BaseService {
    * @param {boolean} [params.force] - Equivalent to -force options in the command line.
    * @param {boolean} [params.propagate] - Auto propagate the chaange or deletion to the dependent resources.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Empty>>}
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>>}
    */
   public deleteResourcesQuery(
     params: SchematicsV1.DeleteResourcesQueryParams
-  ): Promise<SchematicsV1.Response<SchematicsV1.Empty>> {
+  ): Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>> {
     const _params = { ...params };
-    const requiredParams = ['queryId'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['queryId'];
+    const _validParams = ['queryId', 'force', 'propagate', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const path = {
@@ -4234,20 +4883,372 @@ class SchematicsV1 extends BaseService {
     return this.createRequest(parameters);
   }
   /*************************
+   * agent
+   ************************/
+
+  /**
+   * Get all registered/unregistered agents in the Account.
+   *
+   * Get all registered or unregistered agents, in the Account.
+   *    <h3>Authorization</h3>
+   *    Schematics support generic authorization for its resources.
+   *    For more information, about Schematics access and permissions, see [Schematics service access
+   *    roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {number} [params.offset] - The starting position of the item in the list of items. For example, if you have
+   * three workspaces in your account, the first workspace is assigned position number 0, the second workspace is
+   * assigned position number 1, and so forth. If you have 6 workspaces and you want to list the details for workspaces
+   * `2-6`, enter 1. To limit the number of workspaces that is returned, use the `limit` option in addition to the
+   * `offset` option. Negative numbers are not supported and are ignored.
+   * @param {number} [params.limit] - The maximum number of items that you want to list. The number must be a positive
+   * integer between 1 and 2000. If no value is provided, 100 is used by default.
+   * @param {string} [params.profile] - Level of details returned by the get method.
+   * @param {string} [params.filter] - Use `new` to get all unregistered agents; use `saved` to get all registered
+   * agents.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.AgentList>>}
+   * @deprecated this method is deprecated and may be removed in a future release
+   */
+  public listAgent(
+    params?: SchematicsV1.ListAgentParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.AgentList>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: listAgent');
+    const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['offset', 'limit', 'profile', 'filter', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'offset': _params.offset,
+      'limit': _params.limit,
+      'profile': _params.profile,
+      'filter': _params.filter,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listAgent'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/settings/agents',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Register the agent with schematics.
+   *
+   * Register the agent with schematics
+   *    <h3>Authorization</h3>
+   *    Schematics support generic authorization for its resources.
+   *    For more information, about Schematics access and permissions, see [Schematics service access
+   *    roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.name - The name of the agent (must be unique, for an account).
+   * @param {string} params.agentLocation - The location where agent is deployed in the user environment.
+   * @param {string} params.location - List of locations supported by IBM Cloud Schematics service.  While creating your
+   * workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location
+   * of the IBM Cloud resources, provisioned using Schematics.
+   * @param {string} params.profileId - The IAM trusted profile id, used by the Agent instance.
+   * @param {string} [params.description] - Agent description.
+   * @param {string} [params.resourceGroup] - The resource-group name for the agent.  By default, Agent will be
+   * registered in Default Resource Group.
+   * @param {string[]} [params.tags] - Tags for the agent.
+   * @param {AgentUserState} [params.userState] - User defined status of the agent.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Agent>>}
+   * @deprecated this method is deprecated and may be removed in a future release
+   */
+  public registerAgent(
+    params: SchematicsV1.RegisterAgentParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.Agent>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: registerAgent');
+    const _params = { ...params };
+    const _requiredParams = ['name', 'agentLocation', 'location', 'profileId'];
+    const _validParams = ['name', 'agentLocation', 'location', 'profileId', 'description', 'resourceGroup', 'tags', 'userState', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+      'agent_location': _params.agentLocation,
+      'location': _params.location,
+      'profile_id': _params.profileId,
+      'description': _params.description,
+      'resource_group': _params.resourceGroup,
+      'tags': _params.tags,
+      'user_state': _params.userState,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'registerAgent'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/settings/agents',
+        method: 'POST',
+        body,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Get the registered agent details.
+   *
+   * Reterive list the registered agent details
+   *    <h3>Authorization</h3>
+   *    Schematics support generic authorization for its resources.
+   *    For more information, about Schematics access and permissions, see [Schematics service access
+   *    roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.agentId - Agent ID to get the details of agent.
+   * @param {string} [params.profile] - Level of details returned by the get method.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Agent>>}
+   * @deprecated this method is deprecated and may be removed in a future release
+   */
+  public getAgent(
+    params: SchematicsV1.GetAgentParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.Agent>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: getAgent');
+    const _params = { ...params };
+    const _requiredParams = ['agentId'];
+    const _validParams = ['agentId', 'profile', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const query = {
+      'profile': _params.profile,
+    };
+
+    const path = {
+      'agent_id': _params.agentId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getAgent'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/settings/agents/{agent_id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Deregister the agent.
+   *
+   * Deregistering an agent.
+   *    <h3>Authorization</h3>
+   *    Schematics support generic authorization for its resources.
+   *    For more information, about Schematics access and permissions, see [Schematics service access
+   *    roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.agentId - Agent ID to get the details of agent.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>>}
+   * @deprecated this method is deprecated and may be removed in a future release
+   */
+  public deleteAgent(
+    params: SchematicsV1.DeleteAgentParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.EmptyObject>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: deleteAgent');
+    const _params = { ...params };
+    const _requiredParams = ['agentId'];
+    const _validParams = ['agentId', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'agent_id': _params.agentId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'deleteAgent'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/settings/agents/{agent_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Update the agent registration.
+   *
+   * Update the agent registeration.
+   *    <h3>Authorization</h3>
+   *    Schematics support generic authorization for its resources.
+   *    For more information, about Schematics access and permissions, see [Schematics service access
+   *    roles and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.agentId - Agent ID to get the details of agent.
+   * @param {string} params.name - The name of the agent (must be unique, for an account).
+   * @param {string} params.agentLocation - The location where agent is deployed in the user environment.
+   * @param {string} params.location - List of locations supported by IBM Cloud Schematics service.  While creating your
+   * workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location
+   * of the IBM Cloud resources, provisioned using Schematics.
+   * @param {string} params.profileId - The IAM trusted profile id, used by the Agent instance.
+   * @param {string} [params.description] - Agent description.
+   * @param {string} [params.resourceGroup] - The resource-group name for the agent.  By default, Agent will be
+   * registered in Default Resource Group.
+   * @param {string[]} [params.tags] - Tags for the agent.
+   * @param {AgentUserState} [params.userState] - User defined status of the agent.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<SchematicsV1.Response<SchematicsV1.Agent>>}
+   * @deprecated this method is deprecated and may be removed in a future release
+   */
+  public updateAgentRegistration(
+    params: SchematicsV1.UpdateAgentRegistrationParams
+  ): Promise<SchematicsV1.Response<SchematicsV1.Agent>> {
+    SchematicsV1._logger.warn('A deprecated operation has been invoked: updateAgentRegistration');
+    const _params = { ...params };
+    const _requiredParams = ['agentId', 'name', 'agentLocation', 'location', 'profileId'];
+    const _validParams = ['agentId', 'name', 'agentLocation', 'location', 'profileId', 'description', 'resourceGroup', 'tags', 'userState', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'name': _params.name,
+      'agent_location': _params.agentLocation,
+      'location': _params.location,
+      'profile_id': _params.profileId,
+      'description': _params.description,
+      'resource_group': _params.resourceGroup,
+      'tags': _params.tags,
+      'user_state': _params.userState,
+    };
+
+    const path = {
+      'agent_id': _params.agentId,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'updateAgentRegistration'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v2/settings/agents/{agent_id}',
+        method: 'PATCH',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+  /*************************
    * settingsKms
    ************************/
 
   /**
-   * Get KMS settings.
+   * Get a KMS settings.
    *
-   * Retrieve the KMS on the API endpoint that you have access. For example, if you use an API endpoint for a geography,
-   * such as North America, only Schematics resource that are created in `us-south` or `us-east` are retrieved.
-   * <h3>Authorization</h3>
+   * Retrieve the kms instance that is integrated with Schematics for the **byok** and **kyok**. For each geographic
+   * location supported in Schematics we can have different kms settings. For example `US` and `EU` will have different
+   * kms settings. <h3>Authorization</h3>
    *
-   *
-   *  Schematics support generic authorization such as service access or platform access to the action ID and the
-   * resource group. For more information, about Schematics access and permissions, see [Schematics service access roles
-   * and required permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
+   * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.location - The location of the Resource.
@@ -4258,18 +5259,22 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.GetKmsSettingsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.KMSSettings>> {
     const _params = { ...params };
-    const requiredParams = ['location'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['location'];
+    const _validParams = ['location', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
       'location': _params.location,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'getKmsSettings');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getKmsSettings'
+    );
 
     const parameters = {
       options: {
@@ -4293,23 +5298,24 @@ class SchematicsV1 extends BaseService {
   }
 
   /**
-   * Replace KMS settings.
+   * Update a KMS settings.
    *
-   * Replace or Update the KMS setting for your location, by using your private endpoint, `CRN`, primary `CRK`, and
-   * secondary `CRK`. **Note** you can update the KMS settings only once. For example, if you use an API endpoint for a
-   * geography, such as North America, only Schematics resource that are created in `us-south` or `us-east` are
-   * retrieved.
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to the
-   * action ID and the resource group. For more information, about Schematics access and permissions, see  [Schematics
-   * service access roles and required
+   * Replace or Update kms settings for a given location can be updated. **Note** you can update the kms settings only
+   * once. For example, if you use an API endpoint for a geography, such as North America, only kms settings for that
+   * region can be retrieved.  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.location] - Location.
-   * @param {string} [params.encryptionScheme] - Encryption scheme.
-   * @param {string} [params.resourceGroup] - Resource group.
-   * @param {KMSSettingsPrimaryCrk} [params.primaryCrk] - Primary CRK details.
-   * @param {KMSSettingsSecondaryCrk} [params.secondaryCrk] - Secondary CRK details.
+   * @param {string} [params.location] - The location to integrate kms instance. For example, location can be `US` and
+   * `EU`.
+   * @param {string} [params.encryptionScheme] - The encryption scheme values. **Allowable values** [`byok`,`kyok`].
+   * @param {string} [params.resourceGroup] - The kms instance resource group to integrate.
+   * @param {KMSSettingsPrimaryCrk} [params.primaryCrk] - The primary kms instance details.
+   * @param {KMSSettingsSecondaryCrk} [params.secondaryCrk] - The secondary kms instance details.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<SchematicsV1.Response<SchematicsV1.KMSSettings>>}
    */
@@ -4317,6 +5323,12 @@ class SchematicsV1 extends BaseService {
     params?: SchematicsV1.UpdateKmsSettingsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.KMSSettings>> {
     const _params = { ...params };
+    const _requiredParams = [];
+    const _validParams = ['location', 'encryptionScheme', 'resourceGroup', 'primaryCrk', 'secondaryCrk', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
 
     const body = {
       'location': _params.location,
@@ -4326,7 +5338,11 @@ class SchematicsV1 extends BaseService {
       'secondary_crk': _params.secondaryCrk,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'updateKmsSettings');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'updateKmsSettings'
+    );
 
     const parameters = {
       options: {
@@ -4353,11 +5369,13 @@ class SchematicsV1 extends BaseService {
   /**
    * List KMS instances.
    *
-   * Lists the KMS instances of your IBM Cloud account to find your Key Protect or Hyper Protect Crypto Services by
-   * using the location and encrypted scheme such as KYOK or BYOK.
-   * <h3>Authorization</h3> Schematics support generic authorization such as service access or platform access to the
-   * action ID and the resource group. For more information, about Schematics access and permissions, see  [Schematics
-   * service access roles and required
+   * Lists the kms instances of your IBM Cloud account to find your Key Protect or Hyper Protect Crypto Services by
+   * using the location and encrypted scheme.
+   *  <h3>Authorization</h3>
+   *
+   *  Schematics support generic authorization for its resources.
+   *  For more information, about Schematics access and permissions, see
+   *  [Schematics service access roles and required
    * permissions](https://cloud.ibm.com/docs/schematics?topic=schematics-access#access-roles).
    *
    * @param {Object} params - The parameters to send to the service.
@@ -4376,11 +5394,11 @@ class SchematicsV1 extends BaseService {
     params: SchematicsV1.ListKmsParams
   ): Promise<SchematicsV1.Response<SchematicsV1.KMSDiscovery>> {
     const _params = { ...params };
-    const requiredParams = ['encryptionScheme', 'location'];
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return Promise.reject(missingParams);
+    const _requiredParams = ['encryptionScheme', 'location'];
+    const _validParams = ['encryptionScheme', 'location', 'resourceGroup', 'limit', 'sort', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
     }
 
     const query = {
@@ -4391,7 +5409,11 @@ class SchematicsV1 extends BaseService {
       'sort': _params.sort,
     };
 
-    const sdkHeaders = getSdkHeaders(SchematicsV1.DEFAULT_SERVICE_NAME, 'v1', 'listKms');
+    const sdkHeaders = getSdkHeaders(
+      SchematicsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'listKms'
+    );
 
     const parameters = {
       options: {
@@ -4432,7 +5454,7 @@ namespace SchematicsV1 {
   export type Callback<T> = (error: any, response?: Response<T>) => void;
 
   /** The body of a service request that returns no response data. */
-  export interface Empty {}
+  export interface EmptyObject {}
 
   /** A standard JS object, defined to avoid the limitations of `Object` and `object` */
   export interface JsonObject {
@@ -4465,11 +5487,11 @@ namespace SchematicsV1 {
 
   /** Parameters for the `processTemplateMetaData` operation. */
   export interface ProcessTemplateMetaDataParams {
-    /** Template type (terraform, ansible, helm, cloudpak, bash script). */
+    /** Template type such as **terraform**, **ansible**, **helm**, **cloudpak**, or **bash script**. */
     templateType: string;
     /** Source of templates, playbooks, or controls. */
     source: ExternalSource;
-    /** Region to which request should go. Applicable only on global endpoint. */
+    /** Region on which request should process. Applicable only on global endpoint. */
     region?: string;
     /** Type of source for the Template. */
     sourceType?: ProcessTemplateMetaDataConstants.SourceType | string;
@@ -4490,8 +5512,6 @@ namespace SchematicsV1 {
       GIT_LAB = 'git_lab',
       IBM_GIT_LAB = 'ibm_git_lab',
       IBM_CLOUD_CATALOG = 'ibm_cloud_catalog',
-      EXTERNAL_SCM = 'external_scm',
-      COS_BUCKET = 'cos_bucket',
     }
   }
 
@@ -4499,7 +5519,7 @@ namespace SchematicsV1 {
   export interface ListWorkspacesParams {
     /** The starting position of the item in the list of items. For example, if you have three workspaces in your
      *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
-     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces 2-6, enter 1. To limit
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
      *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
      *  numbers are not supported and are ignored.
      */
@@ -4508,17 +5528,30 @@ namespace SchematicsV1 {
      *  If no value is provided, 100 is used by default.
      */
     limit?: number;
+    /** Level of details returned by the get method. */
+    profile?: ListWorkspacesConstants.Profile | string;
     headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `listWorkspaces` operation. */
+  export namespace ListWorkspacesConstants {
+    /** Level of details returned by the get method. */
+    export enum Profile {
+      IDS = 'ids',
+      SUMMARY = 'summary',
+    }
   }
 
   /** Parameters for the `createWorkspace` operation. */
   export interface CreateWorkspaceParams {
-    /** List of applied shared dataset ID. */
+    /** Deprecated: List of applied shared dataset ID. */
     appliedShareddataIds?: string[];
     /** Information about the software template that you chose from the IBM Cloud catalog. This information is
      *  returned for IBM Cloud catalog offerings only.
      */
     catalogRef?: CatalogRef;
+    /** Workspace dependencies. */
+    dependencies?: Dependencies;
     /** The description of the workspace. */
     description?: string;
     /** The location where you want to create your Schematics workspace and run the Schematics jobs. The location
@@ -4551,6 +5584,8 @@ namespace SchematicsV1 {
     type?: string[];
     /** WorkspaceStatusRequest -. */
     workspaceStatus?: WorkspaceStatusRequest;
+    /** agent id which is binded to with the workspace. */
+    agentId?: string;
     /** The personal access token to authenticate with your private GitHub or GitLab repository and access your
      *  Terraform template.
      */
@@ -4575,6 +5610,8 @@ namespace SchematicsV1 {
     catalogRef?: CatalogRef;
     /** The description of the workspace. */
     description?: string;
+    /** Workspace dependencies. */
+    dependencies?: Dependencies;
     /** The name of the workspace. */
     name?: string;
     /** Information about the Target used by the templates originating from the  IBM Cloud catalog offerings. This
@@ -4593,6 +5630,12 @@ namespace SchematicsV1 {
     workspaceStatus?: WorkspaceStatusUpdateRequest;
     /** Information about the last job that ran against the workspace. -. */
     workspaceStatusMsg?: WorkspaceStatusMessage;
+    /** agent id that process workspace jobs. */
+    agentId?: string;
+    /** The personal access token to authenticate with your private GitHub or GitLab repository and access your
+     *  Terraform template.
+     */
+    xGithubToken?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -4601,7 +5644,6 @@ namespace SchematicsV1 {
     /** The IAM refresh token for the user or service identity. The IAM refresh token is required only if you want
      *  to destroy the Terraform resources before deleting the Schematics workspace. If you want to delete the workspace
      *  only and keep all your Terraform resources, refresh token is not required.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -4609,7 +5651,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -4636,6 +5677,8 @@ namespace SchematicsV1 {
     catalogRef?: CatalogRef;
     /** The description of the workspace. */
     description?: string;
+    /** Workspace dependencies. */
+    dependencies?: Dependencies;
     /** The name of the workspace. */
     name?: string;
     /** Information about the Target used by the templates originating from the  IBM Cloud catalog offerings. This
@@ -4654,6 +5697,8 @@ namespace SchematicsV1 {
     workspaceStatus?: WorkspaceStatusUpdateRequest;
     /** Information about the last job that ran against the workspace. -. */
     workspaceStatusMsg?: WorkspaceStatusMessage;
+    /** agent id that process workspace jobs. */
+    agentId?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -4873,7 +5918,7 @@ namespace SchematicsV1 {
   export interface ListActionsParams {
     /** The starting position of the item in the list of items. For example, if you have three workspaces in your
      *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
-     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces 2-6, enter 1. To limit
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
      *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
      *  numbers are not supported and are ignored.
      */
@@ -4914,8 +5959,16 @@ namespace SchematicsV1 {
      *  resources, provisioned using Schematics.
      */
     location?: CreateActionConstants.Location | string;
-    /** Resource-group name for an action.  By default, action is created in default resource group. */
+    /** Resource-group name for an action. By default, an action is created in `Default` resource group. */
     resourceGroup?: string;
+    /** Type of connection to be used when connecting to bastion host.  If the `inventory_connection_type=winrm`,
+     *  then `bastion_connection_type` is not supported.
+     */
+    bastionConnectionType?: CreateActionConstants.BastionConnectionType | string;
+    /** Type of connection to be used when connecting to remote host.  **Note** Currently, WinRM supports only
+     *  Windows system with the public IPs and do not support Bastion host.
+     */
+    inventoryConnectionType?: CreateActionConstants.InventoryConnectionType | string;
     /** Action tags. */
     tags?: string[];
     /** User defined status of the Schematics object. */
@@ -4931,11 +5984,11 @@ namespace SchematicsV1 {
     /** Target inventory record ID, used by the action or ansible playbook. */
     inventory?: string;
     /** credentials of the Action. */
-    credentials?: VariableData[];
+    credentials?: CredentialVariableData[];
     /** Describes a bastion resource. */
     bastion?: BastionResourceDefinition;
-    /** User editable variable data & system generated reference to value. */
-    bastionCredential?: VariableData;
+    /** User editable credential variable data and system generated reference to the value. */
+    bastionCredential?: CredentialVariableData;
     /** Inventory of host and host group for the playbook in `INI` file format. For example, `"targets_ini":
      *  "[webserverhost]
      *   172.22.192.6
@@ -4950,10 +6003,6 @@ namespace SchematicsV1 {
     outputs?: VariableData[];
     /** Environment variables for the Action. */
     settings?: VariableData[];
-    /** Computed state of the Action. */
-    state?: ActionState;
-    /** System lock status. */
-    sysLock?: SystemLock;
     /** The personal access token to authenticate with your private GitHub or GitLab repository and access your
      *  Terraform template.
      */
@@ -4970,6 +6019,15 @@ namespace SchematicsV1 {
       EU_GB = 'eu-gb',
       EU_DE = 'eu-de',
     }
+    /** Type of connection to be used when connecting to bastion host.  If the `inventory_connection_type=winrm`, then `bastion_connection_type` is not supported. */
+    export enum BastionConnectionType {
+      SSH = 'ssh',
+    }
+    /** Type of connection to be used when connecting to remote host.  **Note** Currently, WinRM supports only Windows system with the public IPs and do not support Bastion host. */
+    export enum InventoryConnectionType {
+      SSH = 'ssh',
+      WINRM = 'winrm',
+    }
     /** Type of source for the Template. */
     export enum SourceType {
       LOCAL = 'local',
@@ -4978,8 +6036,6 @@ namespace SchematicsV1 {
       GIT_LAB = 'git_lab',
       IBM_GIT_LAB = 'ibm_git_lab',
       IBM_CLOUD_CATALOG = 'ibm_cloud_catalog',
-      EXTERNAL_SCM = 'external_scm',
-      COS_BUCKET = 'cos_bucket',
     }
   }
 
@@ -4998,6 +6054,7 @@ namespace SchematicsV1 {
     export enum Profile {
       SUMMARY = 'summary',
       DETAILED = 'detailed',
+      IDS = 'ids',
     }
   }
 
@@ -5027,8 +6084,16 @@ namespace SchematicsV1 {
      *  resources, provisioned using Schematics.
      */
     location?: UpdateActionConstants.Location | string;
-    /** Resource-group name for an action.  By default, action is created in default resource group. */
+    /** Resource-group name for an action. By default, an action is created in `Default` resource group. */
     resourceGroup?: string;
+    /** Type of connection to be used when connecting to bastion host.  If the `inventory_connection_type=winrm`,
+     *  then `bastion_connection_type` is not supported.
+     */
+    bastionConnectionType?: UpdateActionConstants.BastionConnectionType | string;
+    /** Type of connection to be used when connecting to remote host.  **Note** Currently, WinRM supports only
+     *  Windows system with the public IPs and do not support Bastion host.
+     */
+    inventoryConnectionType?: UpdateActionConstants.InventoryConnectionType | string;
     /** Action tags. */
     tags?: string[];
     /** User defined status of the Schematics object. */
@@ -5044,11 +6109,11 @@ namespace SchematicsV1 {
     /** Target inventory record ID, used by the action or ansible playbook. */
     inventory?: string;
     /** credentials of the Action. */
-    credentials?: VariableData[];
+    credentials?: CredentialVariableData[];
     /** Describes a bastion resource. */
     bastion?: BastionResourceDefinition;
-    /** User editable variable data & system generated reference to value. */
-    bastionCredential?: VariableData;
+    /** User editable credential variable data and system generated reference to the value. */
+    bastionCredential?: CredentialVariableData;
     /** Inventory of host and host group for the playbook in `INI` file format. For example, `"targets_ini":
      *  "[webserverhost]
      *   172.22.192.6
@@ -5063,10 +6128,6 @@ namespace SchematicsV1 {
     outputs?: VariableData[];
     /** Environment variables for the Action. */
     settings?: VariableData[];
-    /** Computed state of the Action. */
-    state?: ActionState;
-    /** System lock status. */
-    sysLock?: SystemLock;
     /** The personal access token to authenticate with your private GitHub or GitLab repository and access your
      *  Terraform template.
      */
@@ -5083,6 +6144,15 @@ namespace SchematicsV1 {
       EU_GB = 'eu-gb',
       EU_DE = 'eu-de',
     }
+    /** Type of connection to be used when connecting to bastion host.  If the `inventory_connection_type=winrm`, then `bastion_connection_type` is not supported. */
+    export enum BastionConnectionType {
+      SSH = 'ssh',
+    }
+    /** Type of connection to be used when connecting to remote host.  **Note** Currently, WinRM supports only Windows system with the public IPs and do not support Bastion host. */
+    export enum InventoryConnectionType {
+      SSH = 'ssh',
+      WINRM = 'winrm',
+    }
     /** Type of source for the Template. */
     export enum SourceType {
       LOCAL = 'local',
@@ -5091,8 +6161,6 @@ namespace SchematicsV1 {
       GIT_LAB = 'git_lab',
       IBM_GIT_LAB = 'ibm_git_lab',
       IBM_CLOUD_CATALOG = 'ibm_cloud_catalog',
-      EXTERNAL_SCM = 'external_scm',
-      COS_BUCKET = 'cos_bucket',
     }
   }
 
@@ -5113,7 +6181,7 @@ namespace SchematicsV1 {
     wId: string;
     /** The starting position of the item in the list of items. For example, if you have three workspaces in your
      *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
-     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces 2-6, enter 1. To limit
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
      *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
      *  numbers are not supported and are ignored.
      */
@@ -5152,7 +6220,6 @@ namespace SchematicsV1 {
     /** The ID of the workspace.  To find the workspace ID, use the `GET /v1/workspaces` API. */
     wId: string;
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5160,7 +6227,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -5186,7 +6252,6 @@ namespace SchematicsV1 {
      */
     wId: string;
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5194,7 +6259,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -5217,7 +6281,6 @@ namespace SchematicsV1 {
      */
     wId: string;
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5225,7 +6288,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -5248,7 +6310,6 @@ namespace SchematicsV1 {
      */
     wId: string;
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5256,13 +6317,14 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
      *    * When the IAM access token is about to expire, use the API key to create a new access token.
      */
     refreshToken: string;
+    /** Workspace job options template. */
+    actionOptions?: WorkspaceActivityOptionsTemplate;
     /** The IAM delegated token for your IBM Cloud account.  This token is required for requests that are sent via
      *  the UI only.
      */
@@ -5277,7 +6339,6 @@ namespace SchematicsV1 {
      */
     wId: string;
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5285,7 +6346,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -5303,7 +6363,7 @@ namespace SchematicsV1 {
   export interface ListJobsParams {
     /** The starting position of the item in the list of items. For example, if you have three workspaces in your
      *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
-     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces 2-6, enter 1. To limit
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
      *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
      *  numbers are not supported and are ignored.
      */
@@ -5319,12 +6379,14 @@ namespace SchematicsV1 {
     sort?: string;
     /** Level of details returned by the get method. */
     profile?: ListJobsConstants.Profile | string;
-    /** Name of the resource (workspace, actions or controls). */
+    /** Name of the resource (workspaces, actions, environment or controls). */
     resource?: ListJobsConstants.Resource | string;
     /** The Resource Id. It could be an Action-id or Workspace-id. */
     resourceId?: string;
     /** Action Id. */
     actionId?: string;
+    /** Workspace Id. */
+    workspaceId?: string;
     /** list jobs. */
     list?: ListJobsConstants.List | string;
     headers?: OutgoingHttpHeaders;
@@ -5337,10 +6399,12 @@ namespace SchematicsV1 {
       IDS = 'ids',
       SUMMARY = 'summary',
     }
-    /** Name of the resource (workspace, actions or controls). */
+    /** Name of the resource (workspaces, actions, environment or controls). */
     export enum Resource {
-      WORKSPACE = 'workspace',
+      WORKSPACES = 'workspaces',
       ACTION = 'action',
+      ACTIONS = 'actions',
+      ENVIRONMENT = 'environment',
     }
     /** list jobs. */
     export enum List {
@@ -5351,7 +6415,6 @@ namespace SchematicsV1 {
   /** Parameters for the `createJob` operation. */
   export interface CreateJobParams {
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5359,7 +6422,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -5389,12 +6451,16 @@ namespace SchematicsV1 {
     location?: CreateJobConstants.Location | string;
     /** Job Status. */
     status?: JobStatus;
+    /** Contains the cart order data which can be used for different purpose for eg. service tagging. */
+    cartOrderData?: CartOrderData[];
     /** Job data. */
     data?: JobData;
     /** Describes a bastion resource. */
     bastion?: BastionResourceDefinition;
     /** Job log summary record. */
     logSummary?: JobLogSummary;
+    /** Agent name, Agent id and associated policy ID information. */
+    agent?: AgentInfo;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -5406,6 +6472,7 @@ namespace SchematicsV1 {
       ACTION = 'action',
       SYSTEM = 'system',
       ENVIRONMENT = 'environment',
+      BLUEPRINT = 'blueprint',
     }
     /** Schematics job command name. */
     export enum CommandName {
@@ -5432,10 +6499,23 @@ namespace SchematicsV1 {
       CREATE_ENVIRONMENT = 'create_environment',
       PUT_ENVIRONMENT = 'put_environment',
       DELETE_ENVIRONMENT = 'delete_environment',
-      ENVIRONMENT_INIT = 'environment_init',
+      ENVIRONMENT_CREATE_INIT = 'environment_create_init',
+      ENVIRONMENT_UPDATE_INIT = 'environment_update_init',
       ENVIRONMENT_INSTALL = 'environment_install',
       ENVIRONMENT_UNINSTALL = 'environment_uninstall',
+      BLUEPRINT_CREATE_INIT = 'blueprint_create_init',
+      BLUEPRINT_UPDATE_INIT = 'blueprint_update_init',
+      BLUEPRINT_INSTALL = 'blueprint_install',
+      BLUEPRINT_DESTROY = 'blueprint_destroy',
+      BLUEPRINT_DELETE = 'blueprint_delete',
+      BLUEPRINT_PLAN_INIT = 'blueprint_plan_init',
+      BLUEPRINT_PLAN_APPLY = 'blueprint_plan_apply',
+      BLUEPRINT_PLAN_DESTROY = 'blueprint_plan_destroy',
+      BLUEPRINT_RUN_PLAN = 'blueprint_run_plan',
+      BLUEPRINT_RUN_APPLY = 'blueprint_run_apply',
+      BLUEPRINT_RUN_DESTROY = 'blueprint_run_destroy',
       REPOSITORY_PROCESS = 'repository_process',
+      TERRAFORM_COMMANDS = 'terraform_commands',
     }
     /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud resources, provisioned using Schematics. */
     export enum Location {
@@ -5461,6 +6541,7 @@ namespace SchematicsV1 {
     export enum Profile {
       SUMMARY = 'summary',
       DETAILED = 'detailed',
+      IDS = 'ids',
     }
   }
 
@@ -5469,7 +6550,6 @@ namespace SchematicsV1 {
     /** Job Id. Use `GET /v2/jobs` API to look up the Job Ids in your IBM Cloud account. */
     jobId: string;
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5477,7 +6557,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -5507,12 +6586,16 @@ namespace SchematicsV1 {
     location?: UpdateJobConstants.Location | string;
     /** Job Status. */
     status?: JobStatus;
+    /** Contains the cart order data which can be used for different purpose for eg. service tagging. */
+    cartOrderData?: CartOrderData[];
     /** Job data. */
     data?: JobData;
     /** Describes a bastion resource. */
     bastion?: BastionResourceDefinition;
     /** Job log summary record. */
     logSummary?: JobLogSummary;
+    /** Agent name, Agent id and associated policy ID information. */
+    agent?: AgentInfo;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -5524,6 +6607,7 @@ namespace SchematicsV1 {
       ACTION = 'action',
       SYSTEM = 'system',
       ENVIRONMENT = 'environment',
+      BLUEPRINT = 'blueprint',
     }
     /** Schematics job command name. */
     export enum CommandName {
@@ -5550,10 +6634,23 @@ namespace SchematicsV1 {
       CREATE_ENVIRONMENT = 'create_environment',
       PUT_ENVIRONMENT = 'put_environment',
       DELETE_ENVIRONMENT = 'delete_environment',
-      ENVIRONMENT_INIT = 'environment_init',
+      ENVIRONMENT_CREATE_INIT = 'environment_create_init',
+      ENVIRONMENT_UPDATE_INIT = 'environment_update_init',
       ENVIRONMENT_INSTALL = 'environment_install',
       ENVIRONMENT_UNINSTALL = 'environment_uninstall',
+      BLUEPRINT_CREATE_INIT = 'blueprint_create_init',
+      BLUEPRINT_UPDATE_INIT = 'blueprint_update_init',
+      BLUEPRINT_INSTALL = 'blueprint_install',
+      BLUEPRINT_DESTROY = 'blueprint_destroy',
+      BLUEPRINT_DELETE = 'blueprint_delete',
+      BLUEPRINT_PLAN_INIT = 'blueprint_plan_init',
+      BLUEPRINT_PLAN_APPLY = 'blueprint_plan_apply',
+      BLUEPRINT_PLAN_DESTROY = 'blueprint_plan_destroy',
+      BLUEPRINT_RUN_PLAN = 'blueprint_run_plan',
+      BLUEPRINT_RUN_APPLY = 'blueprint_run_apply',
+      BLUEPRINT_RUN_DESTROY = 'blueprint_run_destroy',
       REPOSITORY_PROCESS = 'repository_process',
+      TERRAFORM_COMMANDS = 'terraform_commands',
     }
     /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud resources, provisioned using Schematics. */
     export enum Location {
@@ -5569,7 +6666,6 @@ namespace SchematicsV1 {
     /** Job Id. Use `GET /v2/jobs` API to look up the Job Ids in your IBM Cloud account. */
     jobId: string;
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5577,7 +6673,6 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
@@ -5598,10 +6693,30 @@ namespace SchematicsV1 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `getJobFiles` operation. */
+  export interface GetJobFilesParams {
+    /** Job Id. Use `GET /v2/jobs` API to look up the Job Ids in your IBM Cloud account. */
+    jobId: string;
+    /** The type of file you want to download eg.state_file, plan_json. */
+    fileType: GetJobFilesConstants.FileType | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `getJobFiles` operation. */
+  export namespace GetJobFilesConstants {
+    /** The type of file you want to download eg.state_file, plan_json. */
+    export enum FileType {
+      TEMPLATE_REPO = 'template_repo',
+      README_FILE = 'readme_file',
+      LOG_FILE = 'log_file',
+      STATE_FILE = 'state_file',
+      PLAN_JSON = 'plan_json',
+    }
+  }
+
   /** Parameters for the `createWorkspaceDeletionJob` operation. */
   export interface CreateWorkspaceDeletionJobParams {
     /** The IAM refresh token for the user or service identity.
-     *
      *    **Retrieving refresh token**:
      *    * Use `export IBMCLOUD_API_KEY=<ibmcloud_api_key>`, and execute `curl -X POST
      *  "https://iam.cloud.ibm.com/identity/token" -H "Content-Type: application/x-www-form-urlencoded" -d
@@ -5609,28 +6724,18 @@ namespace SchematicsV1 {
      *    * For more information, about creating IAM access token and API Docs, refer, [IAM access
      *  token](/apidocs/iam-identity-token-api#gettoken-password) and [Create API
      *  key](/apidocs/iam-identity-token-api#create-api-key).
-     *
      *    **Limitation**:
      *    * If the token is expired, you can use `refresh token` to get a new IAM access token.
      *    * The `refresh_token` parameter cannot be used to retrieve a new IAM access token.
      *    * When the IAM access token is about to expire, use the API key to create a new access token.
      */
     refreshToken: string;
-    /** True to delete workspace. */
-    newDeleteWorkspaces?: boolean;
-    /** True to destroy the resources managed by this workspace. */
-    newDestroyResources?: boolean;
-    /** Workspace deletion job name. */
-    newJob?: string;
-    /** Version of the terraform template. */
-    newVersion?: string;
-    /** List of workspaces to be deleted. */
-    newWorkspaces?: string[];
-    /** If set to `true`, refresh_token header configuration is required to delete all the Terraform resources, and
-     *  the Schematics workspace. If set to `false`, you can remove only the workspace. Your Terraform resources are
-     *  still available and must be managed with the resource dashboard or CLI.
-     */
-    destroyResources?: string;
+    /** Job type such as delete of a batch operation. */
+    job?: string;
+    /** A version of the terraform template. */
+    version?: string;
+    /** The List of workspaces to be deleted. */
+    workspaces?: string[];
     headers?: OutgoingHttpHeaders;
   }
 
@@ -5641,11 +6746,171 @@ namespace SchematicsV1 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `listBlueprint` operation. */
+  export interface ListBlueprintParams {
+    /** The starting position of the item in the list of items. For example, if you have three workspaces in your
+     *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
+     *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
+     *  numbers are not supported and are ignored.
+     */
+    offset?: number;
+    /** The maximum number of items that you want to list. The number must be a positive integer between 1 and 2000.
+     *  If no value is provided, 100 is used by default.
+     */
+    limit?: number;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `createBlueprint` operation. */
+  export interface CreateBlueprintParams {
+    /** Blueprint name (unique for an account). */
+    name: string;
+    /** Schema version. */
+    schemaVersion?: string;
+    /** Source of templates, playbooks, or controls. */
+    source?: ExternalSource;
+    /** Blueprint input configuration definition. */
+    config?: BlueprintConfigItem[];
+    /** Blueprint description. */
+    description?: string;
+    /** Resource-group name for the blueprint.  By default, blueprint will be created in Default Resource Group. */
+    resourceGroup?: string;
+    /** Blueprint instance tags. */
+    tags?: string[];
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
+     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
+     *  resources, provisioned using Schematics.
+     */
+    location?: CreateBlueprintConstants.Location | string;
+    /** Additional inputs configuration for the blueprint. */
+    inputs?: VariableData[];
+    /** Input environemnt settings for blueprint. */
+    settings?: VariableData[];
+    /** Flow definitions for all the blueprint command. */
+    flow?: BlueprintFlow;
+    /** User defined status of the Schematics object. */
+    userState?: UserState;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `createBlueprint` operation. */
+  export namespace CreateBlueprintConstants {
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud resources, provisioned using Schematics. */
+    export enum Location {
+      US_SOUTH = 'us-south',
+      US_EAST = 'us-east',
+      EU_GB = 'eu-gb',
+      EU_DE = 'eu-de',
+    }
+  }
+
+  /** Parameters for the `getBlueprint` operation. */
+  export interface GetBlueprintParams {
+    /** Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your IBM Cloud account. */
+    blueprintId: string;
+    /** Level of details returned by the get method. */
+    profile?: GetBlueprintConstants.Profile | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `getBlueprint` operation. */
+  export namespace GetBlueprintConstants {
+    /** Level of details returned by the get method. */
+    export enum Profile {
+      IDS = 'ids',
+      SUMMARY = 'summary',
+    }
+  }
+
+  /** Parameters for the `replaceBlueprint` operation. */
+  export interface ReplaceBlueprintParams {
+    /** Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your IBM Cloud account. */
+    blueprintId: string;
+    /** Blueprint name (unique for an account). */
+    name: string;
+    /** Schema version. */
+    schemaVersion?: string;
+    /** Source of templates, playbooks, or controls. */
+    source?: ExternalSource;
+    /** Blueprint input configuration definition. */
+    config?: BlueprintConfigItem[];
+    /** Blueprint description. */
+    description?: string;
+    /** Resource-group name for the blueprint.  By default, blueprint will be created in Default Resource Group. */
+    resourceGroup?: string;
+    /** Blueprint instance tags. */
+    tags?: string[];
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
+     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
+     *  resources, provisioned using Schematics.
+     */
+    location?: ReplaceBlueprintConstants.Location | string;
+    /** Additional inputs configuration for the blueprint. */
+    inputs?: VariableData[];
+    /** Input environemnt settings for blueprint. */
+    settings?: VariableData[];
+    /** Flow definitions for all the blueprint command. */
+    flow?: BlueprintFlow;
+    /** User defined status of the Schematics object. */
+    userState?: UserState;
+    /** Level of details returned by the get method. */
+    profile?: ReplaceBlueprintConstants.Profile | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `replaceBlueprint` operation. */
+  export namespace ReplaceBlueprintConstants {
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud resources, provisioned using Schematics. */
+    export enum Location {
+      US_SOUTH = 'us-south',
+      US_EAST = 'us-east',
+      EU_GB = 'eu-gb',
+      EU_DE = 'eu-de',
+    }
+    /** Level of details returned by the get method. */
+    export enum Profile {
+      IDS = 'ids',
+      SUMMARY = 'summary',
+    }
+  }
+
+  /** Parameters for the `deleteBlueprint` operation. */
+  export interface DeleteBlueprintParams {
+    /** Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your IBM Cloud account. */
+    blueprintId: string;
+    /** Level of details returned by the get method. */
+    profile?: DeleteBlueprintConstants.Profile | string;
+    /** Destroy the resources before deleting the blueprint. */
+    destroy?: boolean;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `deleteBlueprint` operation. */
+  export namespace DeleteBlueprintConstants {
+    /** Level of details returned by the get method. */
+    export enum Profile {
+      IDS = 'ids',
+      SUMMARY = 'summary',
+    }
+  }
+
+  /** Parameters for the `uploadTemplateTarBlueprint` operation. */
+  export interface UploadTemplateTarBlueprintParams {
+    /** Environment Id.  Use `GET /v2/blueprints` API to look up the order ids in your IBM Cloud account. */
+    blueprintId: string;
+    /** Template tar file. */
+    file?: NodeJS.ReadableStream | Buffer;
+    /** The content type of file. */
+    fileContentType?: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
   /** Parameters for the `listInventories` operation. */
   export interface ListInventoriesParams {
     /** The starting position of the item in the list of items. For example, if you have three workspaces in your
      *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
-     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces 2-6, enter 1. To limit
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
      *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
      *  numbers are not supported and are ignored.
      */
@@ -5716,7 +6981,19 @@ namespace SchematicsV1 {
      *  your IBM Cloud account.
      */
     inventoryId: string;
+    /** Level of details returned by the get method. */
+    profile?: GetInventoryConstants.Profile | string;
     headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `getInventory` operation. */
+  export namespace GetInventoryConstants {
+    /** Level of details returned by the get method. */
+    export enum Profile {
+      SUMMARY = 'summary',
+      DETAILED = 'detailed',
+      IDS = 'ids',
+    }
   }
 
   /** Parameters for the `replaceInventory` operation. */
@@ -5773,52 +7050,11 @@ namespace SchematicsV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `updateInventory` operation. */
-  export interface UpdateInventoryParams {
-    /** Resource Inventory Id.  Use `GET /v2/inventories` API to look up the Resource Inventory definition Ids  in
-     *  your IBM Cloud account.
-     */
-    inventoryId: string;
-    /** The unique name of your Inventory definition. The name can be up to 128 characters long and can include
-     *  alphanumeric characters, spaces, dashes, and underscores.
-     */
-    name?: string;
-    /** The description of your Inventory definition. The description can be up to 2048 characters long in size. */
-    description?: string;
-    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
-     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
-     *  resources, provisioned using Schematics.
-     */
-    location?: UpdateInventoryConstants.Location | string;
-    /** Resource-group name for the Inventory definition.   By default, Inventory definition will be created in
-     *  Default Resource Group.
-     */
-    resourceGroup?: string;
-    /** Input inventory of host and host group for the playbook, in the `.ini` file format. */
-    inventoriesIni?: string;
-    /** Input resource query definitions that is used to dynamically generate the inventory of host and host group
-     *  for the playbook.
-     */
-    resourceQueries?: string[];
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Constants for the `updateInventory` operation. */
-  export namespace UpdateInventoryConstants {
-    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud resources, provisioned using Schematics. */
-    export enum Location {
-      US_SOUTH = 'us-south',
-      US_EAST = 'us-east',
-      EU_GB = 'eu-gb',
-      EU_DE = 'eu-de',
-    }
-  }
-
   /** Parameters for the `listResourceQuery` operation. */
   export interface ListResourceQueryParams {
     /** The starting position of the item in the list of items. For example, if you have three workspaces in your
      *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
-     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces 2-6, enter 1. To limit
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
      *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
      *  numbers are not supported and are ignored.
      */
@@ -5917,6 +7153,140 @@ namespace SchematicsV1 {
     headers?: OutgoingHttpHeaders;
   }
 
+  /** Parameters for the `listAgent` operation. */
+  export interface ListAgentParams {
+    /** The starting position of the item in the list of items. For example, if you have three workspaces in your
+     *  account, the first workspace is assigned position number 0, the second workspace is assigned position number 1,
+     *  and so forth. If you have 6 workspaces and you want to list the details for workspaces `2-6`, enter 1. To limit
+     *  the number of workspaces that is returned, use the `limit` option in addition to the `offset` option. Negative
+     *  numbers are not supported and are ignored.
+     */
+    offset?: number;
+    /** The maximum number of items that you want to list. The number must be a positive integer between 1 and 2000.
+     *  If no value is provided, 100 is used by default.
+     */
+    limit?: number;
+    /** Level of details returned by the get method. */
+    profile?: ListAgentConstants.Profile | string;
+    /** Use `new` to get all unregistered agents; use `saved` to get all registered agents. */
+    filter?: ListAgentConstants.Filter | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `listAgent` operation. */
+  export namespace ListAgentConstants {
+    /** Level of details returned by the get method. */
+    export enum Profile {
+      SUMMARY = 'summary',
+      DETAILED = 'detailed',
+      IDS = 'ids',
+    }
+    /** Use `new` to get all unregistered agents; use `saved` to get all registered agents. */
+    export enum Filter {
+      ALL = 'all',
+      NEW = 'new',
+      SAVED = 'saved',
+    }
+  }
+
+  /** Parameters for the `registerAgent` operation. */
+  export interface RegisterAgentParams {
+    /** The name of the agent (must be unique, for an account). */
+    name: string;
+    /** The location where agent is deployed in the user environment. */
+    agentLocation: string;
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
+     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
+     *  resources, provisioned using Schematics.
+     */
+    location: RegisterAgentConstants.Location | string;
+    /** The IAM trusted profile id, used by the Agent instance. */
+    profileId: string;
+    /** Agent description. */
+    description?: string;
+    /** The resource-group name for the agent.  By default, Agent will be registered in Default Resource Group. */
+    resourceGroup?: string;
+    /** Tags for the agent. */
+    tags?: string[];
+    /** User defined status of the agent. */
+    userState?: AgentUserState;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `registerAgent` operation. */
+  export namespace RegisterAgentConstants {
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud resources, provisioned using Schematics. */
+    export enum Location {
+      US_SOUTH = 'us-south',
+      US_EAST = 'us-east',
+      EU_GB = 'eu-gb',
+      EU_DE = 'eu-de',
+    }
+  }
+
+  /** Parameters for the `getAgent` operation. */
+  export interface GetAgentParams {
+    /** Agent ID to get the details of agent. */
+    agentId: string;
+    /** Level of details returned by the get method. */
+    profile?: GetAgentConstants.Profile | string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `getAgent` operation. */
+  export namespace GetAgentConstants {
+    /** Level of details returned by the get method. */
+    export enum Profile {
+      SUMMARY = 'summary',
+      DETAILED = 'detailed',
+      IDS = 'ids',
+    }
+  }
+
+  /** Parameters for the `deleteAgent` operation. */
+  export interface DeleteAgentParams {
+    /** Agent ID to get the details of agent. */
+    agentId: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `updateAgentRegistration` operation. */
+  export interface UpdateAgentRegistrationParams {
+    /** Agent ID to get the details of agent. */
+    agentId: string;
+    /** The name of the agent (must be unique, for an account). */
+    name: string;
+    /** The location where agent is deployed in the user environment. */
+    agentLocation: string;
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
+     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
+     *  resources, provisioned using Schematics.
+     */
+    location: UpdateAgentRegistrationConstants.Location | string;
+    /** The IAM trusted profile id, used by the Agent instance. */
+    profileId: string;
+    /** Agent description. */
+    description?: string;
+    /** The resource-group name for the agent.  By default, Agent will be registered in Default Resource Group. */
+    resourceGroup?: string;
+    /** Tags for the agent. */
+    tags?: string[];
+    /** User defined status of the agent. */
+    userState?: AgentUserState;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Constants for the `updateAgentRegistration` operation. */
+  export namespace UpdateAgentRegistrationConstants {
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action, choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud resources, provisioned using Schematics. */
+    export enum Location {
+      US_SOUTH = 'us-south',
+      US_EAST = 'us-east',
+      EU_GB = 'eu-gb',
+      EU_DE = 'eu-de',
+    }
+  }
+
   /** Parameters for the `getKmsSettings` operation. */
   export interface GetKmsSettingsParams {
     /** The location of the Resource. */
@@ -5926,15 +7296,15 @@ namespace SchematicsV1 {
 
   /** Parameters for the `updateKmsSettings` operation. */
   export interface UpdateKmsSettingsParams {
-    /** Location. */
+    /** The location to integrate kms instance. For example, location can be `US` and `EU`. */
     location?: string;
-    /** Encryption scheme. */
+    /** The encryption scheme values. **Allowable values** [`byok`,`kyok`]. */
     encryptionScheme?: string;
-    /** Resource group. */
+    /** The kms instance resource group to integrate. */
     resourceGroup?: string;
-    /** Primary CRK details. */
+    /** The primary kms instance details. */
     primaryCrk?: KMSSettingsPrimaryCrk;
-    /** Secondary CRK details. */
+    /** The secondary kms instance details. */
     secondaryCrk?: KMSSettingsSecondaryCrk;
     headers?: OutgoingHttpHeaders;
   }
@@ -5976,8 +7346,16 @@ namespace SchematicsV1 {
      *  resources, provisioned using Schematics.
      */
     location?: string;
-    /** Resource-group name for an action.  By default, action is created in default resource group. */
+    /** Resource-group name for an action. By default, an action is created in `Default` resource group. */
     resource_group?: string;
+    /** Type of connection to be used when connecting to bastion host.  If the `inventory_connection_type=winrm`,
+     *  then `bastion_connection_type` is not supported.
+     */
+    bastion_connection_type?: string;
+    /** Type of connection to be used when connecting to remote host.  **Note** Currently, WinRM supports only
+     *  Windows system with the public IPs and do not support Bastion host.
+     */
+    inventory_connection_type?: string;
     /** Action tags. */
     tags?: string[];
     /** User defined status of the Schematics object. */
@@ -5993,11 +7371,11 @@ namespace SchematicsV1 {
     /** Target inventory record ID, used by the action or ansible playbook. */
     inventory?: string;
     /** credentials of the Action. */
-    credentials?: VariableData[];
+    credentials?: CredentialVariableData[];
     /** Describes a bastion resource. */
     bastion?: BastionResourceDefinition;
-    /** User editable variable data & system generated reference to value. */
-    bastion_credential?: VariableData;
+    /** User editable credential variable data and system generated reference to the value. */
+    bastion_credential?: CredentialVariableData;
     /** Inventory of host and host group for the playbook in `INI` file format. For example, `"targets_ini":
      *  "[webserverhost]
      *   172.22.192.6
@@ -6036,7 +7414,7 @@ namespace SchematicsV1 {
     updated_by?: string;
     /** Computed state of the Action. */
     state?: ActionState;
-    /** Playbook names retrieved from the respository. */
+    /** Playbook names retrieved from the repository. */
     playbook_names?: string[];
     /** System lock status. */
     sys_lock?: SystemLock;
@@ -6091,6 +7469,8 @@ namespace SchematicsV1 {
     updated_at?: string;
     /** Email address of user who updated the action. */
     updated_by?: string;
+    /** Agent name, Agent id and associated policy ID information. */
+    agent?: AgentInfo;
   }
 
   /** Computed state of the Action. */
@@ -6111,12 +7491,347 @@ namespace SchematicsV1 {
     status_message?: string;
   }
 
+  /** The agent registration details, with user inputs and system generated data. */
+  export interface Agent {
+    /** The name of the agent (must be unique, for an account). */
+    name: string;
+    /** Agent description. */
+    description?: string;
+    /** The resource-group name for the agent.  By default, Agent will be registered in Default Resource Group. */
+    resource_group?: string;
+    /** Tags for the agent. */
+    tags?: string[];
+    /** The location where agent is deployed in the user environment. */
+    agent_location: string;
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
+     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
+     *  resources, provisioned using Schematics.
+     */
+    location: string;
+    /** The IAM trusted profile id, used by the Agent instance. */
+    profile_id: string;
+    /** The Agent crn, obtained from the Schematics Agent deployment configuration. */
+    agent_crn?: string;
+    /** The Agent registration id. */
+    id?: string;
+    /** The Agent registration date-time. */
+    registered_at?: string;
+    /** The email address of an user who registered the Agent. */
+    registered_by?: string;
+    /** The Agent registration updation time. */
+    updated_at?: string;
+    /** Email address of user who updated the Agent registration. */
+    updated_by?: string;
+    /** User defined status of the agent. */
+    user_state?: AgentUserState;
+    /** Connection status of the agent. */
+    connection_state?: ConnectionState;
+    /** Computed state of the agent. */
+    system_state?: AgentSystemState;
+  }
+
+  /** Agent name, Agent id and associated policy ID information. */
+  export interface AgentInfo {
+    /** ID of the Agent bound to the schematics object (workspace, action, blueprint). */
+    id?: string;
+    /** Name of the Agent bound to the schematics object. */
+    name?: string;
+    /** ID of the agent assignment policy, that is used to bind the Agent to schematics object. */
+    assignment_policy_id?: string;
+  }
+
+  /** The list of agent details. */
+  export interface AgentList {
+    /** The total number of records. */
+    total_count?: number;
+    /** The number of records returned. */
+    limit?: number;
+    /** The skipped number of records. */
+    offset: number;
+    /** The list of agents in the account. */
+    agents?: Agent[];
+  }
+
+  /** User defined status of the agent. */
+  export interface AgentUserState {
+    /** User-defined states   * `enable`  Agent is enabled by the user.   * `disable` Agent is disbaled by the user. */
+    state?: string;
+    /** Name of the User who set the state of the Object. */
+    set_by?: string;
+    /** When the User who set the state of the Object. */
+    set_at?: string;
+  }
+
+  /** Computed state of the agent. */
+  export interface AgentSystemState {
+    /** Agent Status. */
+    state?: string;
+    /** The Agent status message. */
+    message?: string;
+  }
+
   /** Describes a bastion resource. */
   export interface BastionResourceDefinition {
-    /** Bastion Name(Unique). */
+    /** Bastion Name; the name must be unique. */
     name?: string;
     /** Reference to the Inventory resource definition. */
     host?: string;
+  }
+
+  /** Blueprint details with user inputs and system generated data. */
+  export interface Blueprint {
+    /** Blueprint name (unique for an account). */
+    name: string;
+    /** Schema version. */
+    schema_version?: string;
+    /** Source of templates, playbooks, or controls. */
+    source?: ExternalSource;
+    /** Blueprint input configuration definition. */
+    config?: BlueprintConfigItem[];
+    /** Blueprint description. */
+    description?: string;
+    /** Resource-group name for the blueprint.  By default, blueprint will be created in Default Resource Group. */
+    resource_group?: string;
+    /** Blueprint instance tags. */
+    tags?: string[];
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
+     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
+     *  resources, provisioned using Schematics.
+     */
+    location?: string;
+    /** Additional inputs configuration for the blueprint. */
+    inputs?: VariableData[];
+    /** Input environemnt settings for blueprint. */
+    settings?: VariableData[];
+    /** Output variables for the blueprint. */
+    outputs?: VariableData[];
+    /** Components of the blueprint. */
+    modules?: BlueprintModule[];
+    /** Flow definitions for all the blueprint command. */
+    flow?: BlueprintFlow;
+    /** System generated blueprint Id. */
+    blueprint_id?: string;
+    /** Blueprint CRN. */
+    crn?: string;
+    /** Account id. */
+    account?: string;
+    /** Blueprint creation time. */
+    created_at?: string;
+    /** User who created the blueprint. */
+    created_by?: string;
+    /** Blueprint updation time. */
+    updated_at?: string;
+    /** User who updated the blueprint. */
+    updated_by?: string;
+    /** System lock status. */
+    sys_lock?: SystemLock;
+    /** User defined status of the Schematics object. */
+    user_state?: UserState;
+    /** Computed state of the blueprint. */
+    state?: BlueprintLiteState;
+  }
+
+  /** Blueprint configuration item. */
+  export interface BlueprintConfigItem {
+    /** Name of the blueprint configuration item. */
+    name?: string;
+    /** Description for the blueprint configuration item. */
+    description?: string;
+    /** Source of templates, playbooks, or controls. */
+    source?: ExternalSource;
+    /** Input variables and values for the blueprint configuration item. */
+    inputs?: VariableData[];
+  }
+
+  /** Flow definitions for all the blueprint command. */
+  export interface BlueprintFlow {
+    /** Blueprint flow specification. */
+    specs?: BlueprintFlowSpecs[];
+  }
+
+  /** BlueprintFlowSequenceFlow. */
+  export interface BlueprintFlowSequenceFlow {
+    /** Sequence number in the order or execution. */
+    sequence_number?: number;
+    /** Name of the layer or module to run this command. */
+    item_name?: string;
+  }
+
+  /** BlueprintFlowSpecs. */
+  export interface BlueprintFlowSpecs {
+    /** Schematics job command name. */
+    command_name?: string;
+    /** Type of blueprint flow specification. */
+    flow_type?: string;
+    /** Ordered items in the simple sequence. */
+    sequence_flow?: BlueprintFlowSequenceFlow[];
+    /** Placeholder for conditional flow. */
+    conditional_flow?: string;
+  }
+
+  /** List of Blueprints. */
+  export interface BlueprintList {
+    /** Total number of blueprint records. */
+    total_count?: number;
+    /** Number of blueprint records returned. */
+    limit?: number;
+    /** Skipped number of blueprint records. */
+    offset: number;
+    /** List of blueprints. */
+    blueprints?: BlueprintLite[];
+  }
+
+  /** Blueprint summary profile. */
+  export interface BlueprintLite {
+    /** Blueprint name (unique for an account). */
+    name?: string;
+    source_type?: string;
+    /** Source of templates, playbooks, or controls. */
+    source?: ExternalSourceLite;
+    /** Blueprint description. */
+    description?: string;
+    /** Resource-group name for the blueprint.  By default, blueprint will be created in Default Resource Group. */
+    resource_group?: string;
+    /** Blueprint tags. */
+    tags?: string[];
+    /** List of locations supported by IBM Cloud Schematics service.  While creating your workspace or action,
+     *  choose the right region, since it cannot be changed.  Note, this does not limit the location of the IBM Cloud
+     *  resources, provisioned using Schematics.
+     */
+    location?: string;
+    /** System generated blueprint Id. */
+    id?: string;
+    /** Blueprint CRN. */
+    crn?: string;
+    /** Account id for the blueprint. */
+    account?: string;
+    /** Blueprint creation time. */
+    created_at?: string;
+    /** User who created the Cart order. */
+    created_by?: string;
+    /** Blueprint updation time. */
+    updated_at?: string;
+    /** User who updated the Cart order. */
+    updated_by?: string;
+    /** System lock status. */
+    sys_lock?: SystemLock;
+    /** User defined status of the Schematics object. */
+    user_state?: UserState;
+    /** Computed state of the blueprint. */
+    state?: BlueprintLiteState;
+  }
+
+  /** Computed state of the blueprint. */
+  export interface BlueprintLiteState {
+    /** User-defined states
+     *    * `Blueprint_Create_Init` When Create Blueprint POST API is invoked and CreateBlueprint process is initiated.
+     *    * `Blueprint_Create_InProgress` When Create Blueprint process is in progress.
+     *    * `Blueprint_Create_Success` Repos are downloaded and underlying objects are created
+     *    * `Blueprint_Create_Failed` Failed to create Blueprint or underlying schematics objects.
+     */
+    status_code?: string;
+    /** Automation status message - to be displayed along with the status_code. */
+    status_message?: string;
+    /** Status of overall Blueprint. */
+    summary_status?: string;
+    /** Status of Blueprint Spec. */
+    config_status?: string;
+    /** Status of Blueprint Plan. */
+    plan_status?: string;
+    /** Status of Blueprint Run Job. */
+    run_status?: string;
+    /** Status of Blueprint Resource. */
+    resource_status?: string;
+  }
+
+  /** Component for the Blueprint. */
+  export interface BlueprintModule {
+    /** Module id. */
+    module_id?: string;
+    /** Name of the Schematics automation resource. */
+    module_type?: string;
+    /** Name of the module. */
+    name?: string;
+    /** Layer for the module. */
+    layer?: string;
+    /** Source of templates, playbooks, or controls. */
+    source?: ExternalSource;
+    /** Array of injectable terraform blocks. */
+    injectors?: InjectTerraformTemplateInner[];
+    /** Tags used by the module. */
+    tags?: string;
+    /** The description of the module. */
+    description?: string;
+    /** The timestamp when the module was created. */
+    created_at?: string;
+    /** The user ID that created the module. */
+    created_by?: string;
+    /** The timestamp when the module was updated. */
+    updated_at?: string;
+    /** The user ID that updated the module. */
+    updated_by?: string;
+    /** The Terraform version of the module that was used to run your Terraform code. */
+    version?: string[];
+    /** Status of the module. */
+    status?: string;
+    /** Location of the module. */
+    location?: string;
+    /** Inputs used by the module. */
+    inputs?: VariableData[];
+    /** Environment settings for the module. */
+    settings?: VariableData[];
+    /** True, when the blueprint module settings is updated or changed. */
+    updated?: boolean;
+    /** True, when there are deletions in the blueprint module settings. */
+    deleted?: boolean;
+    /** Outputs from the module. */
+    outputs?: BlueprintVariableData[];
+    /** Status of the last job executed by the module. */
+    last_job?: BlueprintModuleLastJob;
+  }
+
+  /** Status of the last job executed by the module. */
+  export interface BlueprintModuleLastJob {
+    /** Name of the Schematics automation resource. */
+    command_object?: string;
+    /** Name of the command object id, maps to workspace_name or action_name. */
+    command_object_name?: string;
+    /** Module command object id, maps to workspace_id or action_id. */
+    command_object_id?: string;
+    /** Schematics job command name. */
+    command_name?: string;
+    /** Status of Jobs. */
+    job_status?: string;
+  }
+
+  /** Response after uploading Blueprint Template in tar file format. */
+  export interface BlueprintTemplateRepoTarUploadResponse {
+    /** Tar file value. */
+    file_value?: string;
+    /** Has received tar file?. */
+    has_received_file?: boolean;
+  }
+
+  /** User editable variable data & system generated reference to value. */
+  export interface BlueprintVariableData {
+    /** Name of the variable. */
+    name?: string;
+    /** Value for the variable or reference to the value. */
+    value?: string;
+    /** Reference link to the variable value By default the expression will point to self.value. */
+    link?: string;
+  }
+
+  /** Schematics Cart Order Data. */
+  export interface CartOrderData {
+    /** Name of the property. */
+    name?: string;
+    /** Value of the property. */
+    value?: string;
+    /** Type of the values(string, int etc). */
+    type?: string;
+    /** List of usage kind how the cart data can be used. */
+    usage_kind?: string[];
   }
 
   /** Information about the software template that you chose from the IBM Cloud catalog. This information is returned for IBM Cloud catalog offerings only. */
@@ -6141,6 +7856,163 @@ namespace SchematicsV1 {
     launch_url?: string;
     /** The version of the software template that you chose to install from the IBM Cloud catalog. */
     offering_version?: string;
+    service_extensions?: ServiceExtensions[];
+  }
+
+  /** The connection details to the IBM Cloud Catalog source. */
+  export interface CatalogSource {
+    /** The name of the private catalog. */
+    catalog_name?: string;
+    /** The ID of a private catalog. */
+    catalog_id?: string;
+    /** The name of an offering in the IBM Cloud Catalog. */
+    offering_name?: string;
+    /** The version of the software template that you chose to install from the IBM Cloud catalog. */
+    offering_version?: string;
+    /** The type of an offering, in the IBM Cloud Catalog. */
+    offering_kind?: string;
+    /** Offering Target Kind. */
+    offering_target_kind?: string;
+    /** The ID of an offering in the IBM Cloud Catalog. */
+    offering_id?: string;
+    /** The ID of an offering version the IBM Cloud Catalog. */
+    offering_version_id?: string;
+    /** Offering version flavour name. */
+    offering_version_flavour_name?: string;
+    /** The repository URL of an offering, in the IBM Cloud Catalog. */
+    offering_repo_url?: string;
+    /** Root folder name in .tgz file. */
+    offering_provisioner_working_directory?: string;
+    /** Dry run. */
+    dry_run?: boolean;
+    /** Owning account ID of the catalog. */
+    owning_account?: string;
+    /** The URL to the icon of the software template in the IBM Cloud catalog. */
+    item_icon_url?: string;
+    /** The ID of the software template that you chose to install from the IBM Cloud catalog. This software is
+     *  provisioned with Schematics.
+     */
+    item_id?: string;
+    /** The name of the software that you chose to install from the IBM Cloud catalog. */
+    item_name?: string;
+    /** The URL to the readme file of the software template in the IBM Cloud catalog. */
+    item_readme_url?: string;
+    /** The URL to the software template in the IBM Cloud catalog. */
+    item_url?: string;
+    /** The URL to the dashboard to access your software. */
+    launch_url?: string;
+  }
+
+  /** The connection details to the IBM Cloud Catalog source. */
+  export interface CatalogSourceLite {
+    /** The name of the private catalog. */
+    catalog_name?: string;
+    /** The ID of a private catalog. */
+    catalog_id?: string;
+    /** The name of an offering in the IBM Cloud Catalog. */
+    offering_name?: string;
+    /** The version of the software template that you chose to install from the IBM Cloud catalog. */
+    offering_version?: string;
+    /** The type of an offering, in the IBM Cloud Catalog. */
+    offering_kind?: string;
+    /** Offering Target Kind. */
+    offering_target_kind?: string;
+    /** The ID of an offering in the IBM Cloud Catalog. */
+    offering_id?: string;
+    /** The ID of an offering version the IBM Cloud Catalog. */
+    offering_version_id?: string;
+    /** Offering version flavour name. */
+    offering_version_flavour_name?: string;
+    /** The ID of the software template that you chose to install from the IBM Cloud catalog. This software is
+     *  provisioned with Schematics.
+     */
+    item_id?: string;
+    /** The name of the software that you chose to install from the IBM Cloud catalog. */
+    item_name?: string;
+  }
+
+  /** Workspace commands run as part of the job. */
+  export interface CommandsInfo {
+    /** Name of the command. */
+    name?: string;
+    /** outcome of the command. */
+    outcome?: string;
+  }
+
+  /** Connection status of the agent. */
+  export interface ConnectionState {
+    /** Agent Connection Status
+     *    * `Connected` When Schematics is able to connect to the agent.
+     *    * `Disconnected` When Schematics is able not connect to the agent.
+     */
+    state?: string;
+    /** When the connection state is modified. */
+    checked_at?: string;
+  }
+
+  /** User editable credential variable data and system generated reference to the value. */
+  export interface CredentialVariableData {
+    /** The name of the credential variable. */
+    name?: string;
+    /** The credential value for the variable or reference to the value. For example, `value = "<provide your
+     *  ssh_key_value with \n>"`. **Note** The SSH key should contain `\n` at the end of the key details in case of
+     *  command line or API calls.
+     */
+    value?: string;
+    /** True, will ignore the data in the value attribute, instead the data in metadata.default_value will be used. */
+    use_default?: boolean;
+    /** An user editable metadata for the credential variables. */
+    metadata?: CredentialVariableMetadata;
+    /** The reference link to the variable value By default the expression points to `$self.value`. */
+    link?: string;
+  }
+
+  /** An user editable metadata for the credential variables. */
+  export interface CredentialVariableMetadata {
+    /** Type of the variable. */
+    type?: string;
+    /** The list of aliases for the variable name. */
+    aliases?: string[];
+    /** The description of the meta data. */
+    description?: string;
+    /** Cloud data type of the credential variable. eg. api_key, iam_token, profile_id. */
+    cloud_data_type?: string;
+    /** Default value for the variable only if the override value is not specified. */
+    default_value?: string;
+    /** The status of the link. */
+    link_status?: string;
+    /** Is the variable readonly ?. */
+    immutable?: boolean;
+    /** If **true**, the variable is not displayed on UI or Command line. */
+    hidden?: boolean;
+    /** If the variable required?. */
+    required?: boolean;
+    /** The relative position of this variable in a list. */
+    position?: number;
+    /** The display name of the group this variable belongs to. */
+    group_by?: string;
+    /** The source of this meta-data. */
+    source?: string;
+  }
+
+  /** Workspace dependencies. */
+  export interface Dependencies {
+    /** List of workspace parents CRN identifiers. */
+    parents?: string[];
+    /** List of workspace children CRN identifiers. */
+    children?: string[];
+  }
+
+  /** One variable is a map where one entry is there with key as name of the env var and the value as value. */
+  export interface EnvVariableRequestMap {
+    /** Environment variable is hidden. */
+    hidden?: boolean;
+    /** Environment variable name. */
+    name?: string;
+    /** Environment variable is secure. */
+    secure?: boolean;
+    /** Value for environment variable. */
+    value?: string;
   }
 
   /** List of environment values. */
@@ -6155,59 +8027,92 @@ namespace SchematicsV1 {
     value?: string;
   }
 
+  /** Environment variables metadata. */
+  export interface EnvironmentValuesMetadata {
+    /** Environment variable is hidden. */
+    hidden?: boolean;
+    /** Environment variable name. */
+    name?: string;
+    /** Environment variable is secure. */
+    secure?: boolean;
+  }
+
   /** Source of templates, playbooks, or controls. */
   export interface ExternalSource {
     /** Type of source for the Template. */
     source_type: string;
-    /** Connection details to Git source. */
-    git?: ExternalSourceGit;
-    /** Connection details to IBM Cloud Catalog source. */
-    catalog?: ExternalSourceCatalog;
-    /** Connection details to a IBM Cloud Object Storage bucket. */
-    cos_bucket?: ExternalSourceCosBucket;
+    /** The connection details to the Git source repository. */
+    git?: GitSource;
+    /** The connection details to the IBM Cloud Catalog source. */
+    catalog?: CatalogSource;
   }
 
-  /** Connection details to IBM Cloud Catalog source. */
-  export interface ExternalSourceCatalog {
-    /** name of the private catalog. */
-    catalog_name?: string;
-    /** Name of the offering in the IBM Catalog. */
-    offering_name?: string;
-    /** Version string of the offering in the IBM Catalog. */
-    offering_version?: string;
-    /** Type of the offering, in the IBM Catalog. */
-    offering_kind?: string;
-    /** Id of the offering the IBM Catalog. */
-    offering_id?: string;
-    /** Id of the offering version the IBM Catalog. */
-    offering_version_id?: string;
-    /** Repo Url of the offering, in the IBM Catalog. */
-    offering_repo_url?: string;
+  /** Source of templates, playbooks, or controls. */
+  export interface ExternalSourceLite {
+    /** Type of source for the Template. */
+    source_type: string;
+    /** The connection details to the Git source repository. */
+    git?: GitSourceLite;
+    /** The connection details to the IBM Cloud Catalog source. */
+    catalog?: CatalogSourceLite;
   }
 
-  /** Connection details to a IBM Cloud Object Storage bucket. */
-  export interface ExternalSourceCosBucket {
-    /** COS Bucket Url. */
-    cos_bucket_url?: string;
-  }
-
-  /** Connection details to Git source. */
-  export interface ExternalSourceGit {
-    /** The Complete URL which is computed by git_repo_url, git_repo_folder and branch. */
+  /** The connection details to the Git source repository. */
+  export interface GitSource {
+    /** The complete URL which is computed by the **git_repo_url**, **git_repo_folder**, and **branch**. */
     computed_git_repo_url?: string;
-    /** URL to the GIT Repo that can be used to clone the template. */
+    /** The URL to the Git repository that can be used to clone the template. */
     git_repo_url?: string;
-    /** Personal Access Token to connect to Git URLs. */
+    /** The Personal Access Token (PAT) to connect to the Git URLs. */
     git_token?: string;
-    /** Name of the folder in the Git Repo, that contains the template. */
+    /** The name of the folder in the Git repository, that contains the template. */
     git_repo_folder?: string;
-    /** Name of the release tag, used to fetch the Git Repo. */
+    /** The name of the release tag that are used to fetch the Git repository. */
     git_release?: string;
-    /** Name of the branch, used to fetch the Git Repo. */
+    /** The name of the branch that are used to fetch the Git repository. */
     git_branch?: string;
+    /** The git commit hash used to fetch the repository. */
+    git_commit?: string;
+    /** The timestamp of the git commit hash used to fetch the repository. */
+    git_commit_timestamp?: string;
   }
 
-  /** Complete inventory resource details with user inputs and system generated data. */
+  /** The connection details to the Git source repository. */
+  export interface GitSourceLite {
+    /** The URL to the Git repository that can be used to clone the template. */
+    git_repo_url?: string;
+    /** The name of the release tag that are used to fetch the Git repository. */
+    git_release?: string;
+    /** The name of the branch that are used to fetch the Git repository. */
+    git_branch?: string;
+    /** The name of the folder in the Git repository, that contains the template. */
+    git_repo_folder?: string;
+  }
+
+  /** InjectTerraformTemplateInnerTftParametersItem. */
+  export interface InjectTerraformTemplateInnerTftParametersItem {
+    /** Key name to replace. */
+    name?: string;
+    /** Value to replace. */
+    value?: string;
+  }
+
+  /** InjectTerraformTemplateInner. */
+  export interface InjectTerraformTemplateInner {
+    /** Git repo url hosting terraform template files. */
+    tft_git_url?: string;
+    /** Token to access the git repository (Optional). */
+    tft_git_token?: string;
+    /** Optional prefix word to append to files (Optional). */
+    tft_prefix?: string;
+    /** Injection type. Default is 'override'. */
+    injection_type?: string;
+    /** Terraform template name. Maps to folder name in git repo. */
+    tft_name?: string;
+    tft_parameters?: InjectTerraformTemplateInnerTftParametersItem[];
+  }
+
+  /** Complete inventory definition details. */
   export interface InventoryResourceRecord {
     /** The unique name of your Inventory.  The name can be up to 128 characters long and can include alphanumeric
      *  characters, spaces, dashes, and underscores.
@@ -6299,6 +8204,8 @@ namespace SchematicsV1 {
     duration?: string;
     /** Job Status. */
     status?: JobStatus;
+    /** Contains the cart order data which can be used for different purpose for eg. service tagging. */
+    cart_order_data?: CartOrderData[];
     /** Job data. */
     data?: JobData;
     /** Describes a bastion resource. */
@@ -6313,6 +8220,10 @@ namespace SchematicsV1 {
     results_url?: string;
     /** Job status updation timestamp. */
     updated_at?: string;
+    /** ID of the Job Runner. */
+    job_runner_id?: string;
+    /** Agent name, Agent id and associated policy ID information. */
+    agent?: AgentInfo;
   }
 
   /** Job data. */
@@ -6341,7 +8252,7 @@ namespace SchematicsV1 {
     settings?: VariableData[];
     /** Job status updation timestamp. */
     updated_at?: string;
-    /** Complete inventory resource details with user inputs and system generated data. */
+    /** Complete inventory definition details. */
     inventory_record?: InventoryResourceRecord;
     /** Materialized inventory details used by the Action Job, in .ini format. */
     materialized_inventory?: string;
@@ -6447,6 +8358,42 @@ namespace SchematicsV1 {
     updated_at?: string;
   }
 
+  /** JobFileContent. */
+  export interface JobFileContent {
+    /** Name of the file. */
+    file_name?: string;
+    /** Content of the file, generated by the job. */
+    file_content?: string;
+  }
+
+  /** Output files from the Job record. */
+  export interface JobFileData {
+    /** Job Id. */
+    job_id?: string;
+    /** Job name, uniquely derived from the related Workspace and Action. */
+    job_name?: string;
+    /** Summary metadata in the output files. */
+    summary?: JobFileDataSummary[];
+    /** The type of output file generated by the Job. */
+    file_type?: string;
+    /** Content of the file, generated by the job. */
+    file_content?: string;
+    /** Content of the additional files, generated by the child job. */
+    additional_files?: JobFileContent[];
+    /** Job file updation timestamp. */
+    updated_at?: string;
+  }
+
+  /** JobFileDataSummary. */
+  export interface JobFileDataSummary {
+    /** Summary feature name. */
+    name?: string;
+    /** Summary feature type. */
+    type?: string;
+    /** Summary feature value. */
+    value?: string;
+  }
+
   /** List of Job details. */
   export interface JobList {
     /** Total number of records. */
@@ -6498,6 +8445,10 @@ namespace SchematicsV1 {
     log_summary?: JobLogSummary;
     /** Job status updation timestamp. */
     updated_at?: string;
+    /** ID of the Job Runner. */
+    job_runner_id?: string;
+    /** Agent name, Agent id and associated policy ID information. */
+    agent?: AgentInfo;
   }
 
   /** Job Log details. */
@@ -6643,6 +8594,10 @@ namespace SchematicsV1 {
 
   /** Job Status. */
   export interface JobStatus {
+    /** Position of job in pending queue. */
+    position_in_queue?: number;
+    /** Total no. of jobs in pending queue. */
+    total_in_queue?: number;
     /** Workspace Job Status. */
     workspace_job_status?: JobStatusWorkspace;
     /** Action Job Status. */
@@ -6759,82 +8714,94 @@ namespace SchematicsV1 {
     template_status?: JobStatusTemplate[];
     /** Job status updation timestamp. */
     updated_at?: string;
+    /** List of terraform commands executed and their status. */
+    commands?: CommandsInfo[];
   }
 
-  /** Discovered KMS instances. */
+  /** Discover kms instances in the account based on location. */
   export interface KMSDiscovery {
-    /** Total number of records. */
+    /** The total number of records. */
     total_count?: number;
-    /** Number of records returned. */
+    /** The number of records returned. */
     limit: number;
-    /** Skipped number of records. */
+    /** The skipped number of records. */
     offset: number;
-    /** List of KMS instances. */
+    /** The list of kms instances. */
     kms_instances?: KMSInstances[];
   }
 
-  /** KMS Instances. */
+  /** User defined kms instances. */
   export interface KMSInstances {
-    /** Location. */
+    /** The location to integrate kms instance. For example, location can be `US` and `EU`. */
     location?: string;
-    /** Encryption schema. */
+    /** The encryption scheme values. **Allowable values** [`byok`,`kyok`]. */
     encryption_scheme?: string;
-    /** Resource groups. */
+    /** The kms instance resource group to integrate. */
     resource_group?: string;
-    /** KMS CRN. */
+    /** The primary kms CRN information. */
     kms_crn?: string;
-    /** KMS Name. */
+    /** The kms instance name. */
     kms_name?: string;
-    /** KMS private endpoint. */
+    /** The kms instance private endpoints. */
     kms_private_endpoint?: string;
-    /** KMS public endpoint. */
+    /** The kms instance public endpoints. */
     kms_public_endpoint?: string;
-    /** List of keys. */
+    /** Detailed list of keys. */
     keys?: KMSInstancesKeys[];
   }
 
   /** KMSInstancesKeys. */
   export interface KMSInstancesKeys {
-    /** Key name. */
+    /** The name of the root key. */
     name?: string;
-    /** CRN of the Key. */
+    /** The kms CRN of the root key. */
     crn?: string;
-    /** Error message. */
+    /** The error message details. */
     error?: string;
   }
 
-  /** User defined KMS Settings details. */
+  /** User defined kms settings information. */
   export interface KMSSettings {
-    /** Location. */
+    /** The location to integrate kms instance. For example, location can be `US` and `EU`. */
     location?: string;
-    /** Encryption scheme. */
+    /** The encryption scheme values. **Allowable values** [`byok`,`kyok`]. */
     encryption_scheme?: string;
-    /** Resource group. */
+    /** The kms instance resource group to integrate. */
     resource_group?: string;
-    /** Primary CRK details. */
+    /** The primary kms instance details. */
     primary_crk?: KMSSettingsPrimaryCrk;
-    /** Secondary CRK details. */
+    /** The secondary kms instance details. */
     secondary_crk?: KMSSettingsSecondaryCrk;
   }
 
-  /** Primary CRK details. */
+  /** The primary kms instance details. */
   export interface KMSSettingsPrimaryCrk {
-    /** Primary KMS name. */
+    /** The primary kms instance name. */
     kms_name?: string;
-    /** Primary KMS endpoint. */
+    /** The primary kms instance private endpoint. */
     kms_private_endpoint?: string;
-    /** CRN of the Primary Key. */
+    /** The CRN of the primary root key. */
     key_crn?: string;
   }
 
-  /** Secondary CRK details. */
+  /** The secondary kms instance details. */
   export interface KMSSettingsSecondaryCrk {
-    /** Secondary KMS name. */
+    /** The secondary kms instance name. */
     kms_name?: string;
-    /** Secondary KMS endpoint. */
+    /** The secondary kms instance private endpoint. */
     kms_private_endpoint?: string;
-    /** CRN of the Secondary Key. */
+    /** The CRN of the secondary key. */
     key_crn?: string;
+  }
+
+  /** Last job details. */
+  export interface LastJob {
+    /** ID of last job. */
+    job_id?: string;
+    /** Name of the last job. */
+    job_name?: string;
+    /** Status of the last job. */
+    job_status?: string;
   }
 
   /** Log file URL for job that ran against your workspace. */
@@ -6858,14 +8825,11 @@ namespace SchematicsV1 {
   /** Summary information extracted from the job logs. */
   export interface LogSummary {
     /** The status of your activity or job. To retrieve the URL to your job logs, use the GET
-     *  /v1/workspaces/{id}/actions/{action_id}/logs API.
-     *
-     *  * **COMPLETED**: The job completed successfully.
-     *  * **CREATED**: The job was created, but the provisioning, modification, or removal of IBM Cloud resources has
-     *  not started yet.
-     *  * **FAILED**: An error occurred during the plan, apply, or destroy job. Use the job ID to retrieve the URL to
-     *  the log files for your job.
-     *  * **IN PROGRESS**: The job is in progress. You can use the log_url to access the logs.
+     *  /v1/workspaces/{id}/actions/{action_id}/logs API. * **COMPLETED**: The job completed successfully. *
+     *  **CREATED**: The job was created, but the provisioning, modification, or removal of IBM Cloud resources has not
+     *  started yet. * **FAILED**: An error occurred during the plan, apply, or destroy job. Use the job ID to retrieve
+     *  the URL to the log files for your job. * **IN PROGRESS**: The job is in progress. You can use the log_url to
+     *  access the logs.
      */
     activity_status?: string;
     /** Template detected type. */
@@ -6966,7 +8930,7 @@ namespace SchematicsV1 {
     limit: number;
     /** Skipped number of records. */
     offset: number;
-    /** List of resource query records. */
+    /** List of resource query records. (Deprecated ResourceQueries. Instead, use resource_queries.). */
     resource_queries?: ResourceQueryRecord[];
   }
 
@@ -7011,36 +8975,52 @@ namespace SchematicsV1 {
     multizone_metro?: string;
     /** The kind of location. */
     kind?: string;
-    /** List of paired regions used by Schematics. */
+    /** The list of paired regions used by Schematics. */
     paired_region?: string[];
-    /** Restricted Region. */
+    /** The restricted region. */
     restricted?: boolean;
   }
 
-  /** List of Locations details. */
+  /** The list of locations details. */
   export interface SchematicsLocationsList {
-    /** List of Locations. */
+    /** The list of locations. */
     locations?: SchematicsLocationsLite[];
   }
 
-  /** individual location details. */
+  /** An individual location details. */
   export interface SchematicsLocationsLite {
-    /** Geographical Region code having the data centres of IBM Cloud Schematics service. */
+    /** The Geographical region code having the data centres of the IBM Cloud Schematics service. */
     region?: string;
-    /** Geographical city locations having the data centres of IBM Cloud Schematics service. */
+    /** The Geographical city locations having the data centres of the IBM Cloud Schematics service. */
     metro?: string;
-    /** Geographical continent locations code having the data centres of IBM Cloud Schematics service. */
+    /** The Geographical continent locations code having the data centres of the IBM Cloud Schematics service. */
     geography_code?: string;
-    /** Geographical continent locations having the data centres of IBM Cloud Schematics service. */
+    /** The Geographical continent locations having the data centres of the IBM Cloud Schematics service. */
     geography?: string;
-    /** Country locations having the data centres of IBM Cloud Schematics service. */
+    /** The Country locations having the data centres of the IBM Cloud Schematics service. */
     country?: string;
     /** The kind of location. */
     kind?: string;
-    /** List of paired regions used by Schematics. */
+    /** The list of paired regions used by the Schematics. */
     paired_region?: string[];
-    /** Restricted Region. */
+    /** The restricted region. */
     restricted?: boolean;
+    /** Display name for the region. */
+    display_name?: string;
+    /** Schematics public endpoint for the region. */
+    schematics_regional_public_endpoint?: string;
+    /** Schematics private endpoint for the region. */
+    schematics_regional_private_endpoint?: string;
+  }
+
+  /** Service Extensions. */
+  export interface ServiceExtensions {
+    /** Name of the Service Data. */
+    name?: string;
+    /** Value of the Service Data. */
+    value?: string;
+    /** Type of the value string, int, bool. */
+    type?: string;
   }
 
   /** Information about the Target used by the templates originating from the  IBM Cloud catalog offerings. This information is not relevant for workspace created using your own Terraform template. */
@@ -7134,7 +9114,7 @@ namespace SchematicsV1 {
 
   /** Template metadata response. */
   export interface TemplateMetaDataResponse {
-    /** Template type (terraform, ansible, helm, cloudpak, bash script). */
+    /** The template type such as **terraform**, **ansible**, **helm**, **cloudpak**, or **bash script**. */
     type?: string;
     /** List of variables and its metadata. */
     variables: VariableData[];
@@ -7172,13 +9152,15 @@ namespace SchematicsV1 {
     release?: string;
     /** The repository SHA value. */
     repo_sha_value?: string;
-    /** The repository URL. */
+    /** The repository URL. For more information, about using `.netrc` in `env_values`, see [Usage of private module
+     *  template](https://cloud.ibm.com/docs/schematics?topic=schematics-download-modules-pvt-git).
+     */
     repo_url?: string;
     /** The source URL. */
     url?: string;
   }
 
-  /** TemplateRepoTarUploadResponse -. */
+  /** Response after uploading Template in tar file format. */
   export interface TemplateRepoTarUploadResponse {
     /** Tar file value. */
     file_value?: string;
@@ -7210,6 +9192,8 @@ namespace SchematicsV1 {
     folder?: string;
     /** The ID that was assigned to your Terraform template or IBM Cloud catalog software template. */
     id?: string;
+    /** Last refreshed timestamp of the terraform resource. */
+    generated_at?: string;
     /** List of null resources. */
     null_resources?: JsonObject[];
     /** Information about the IBM Cloud resources that are associated with your workspace. */
@@ -7223,7 +9207,7 @@ namespace SchematicsV1 {
     /** Number of resources. */
     resources_count?: number;
     /** The Terraform version that was used to apply your template. */
-    template_type?: string;
+    type?: string;
   }
 
   /** Information about the provisioning engine, state file, and runtime logs. */
@@ -7264,10 +9248,13 @@ namespace SchematicsV1 {
      *  supported by Schematics.
      */
     env_values?: JsonObject[];
+    /** Environment variables metadata. */
+    env_values_metadata?: EnvironmentValuesMetadata[];
     /** The subfolder in your GitHub or GitLab repository where your Terraform template is stored. */
     folder?: string;
     /** True, to use the files from the specified folder & subfolder in your GitHub or GitLab repository and ignore
-     *  the other folders in the repository.
+     *  the other folders in the repository. For more information, see [Compact download for Schematics
+     *  workspace](https://cloud.ibm.com/docs/schematics?topic=schematics-compact-download&interface=ui).
      */
     compact?: boolean;
     /** The content of an existing Terraform statefile that you want to import in to your workspace. To get the
@@ -7275,10 +9262,13 @@ namespace SchematicsV1 {
      *  terraform state pull --id <workspace_id> --template <template_id>`.
      */
     init_state_file?: string;
-    /** The Terraform version that you want to use to run your Terraform code. Enter `terraform_v0.12` to use
-     *  Terraform version 0.12, and `terraform_v0.11` to use Terraform version 0.11. The Terraform config files are run
-     *  with Terraform version 0.11. This is a required variable. Make sure that your Terraform config files are
-     *  compatible with the Terraform version that you select.
+    /** Array of injectable terraform blocks. */
+    injectors?: InjectTerraformTemplateInner[];
+    /** The Terraform version that you want to use to run your Terraform code. Enter `terraform_v1.1` to use
+     *  Terraform version 1.1, and `terraform_v1.0` to use Terraform version 1.0. This is a required variable. If the
+     *  Terraform version is not specified, By default, Schematics selects the version from your template. For more
+     *  information, refer to [Terraform
+     *  version](https://cloud.ibm.com/docs/schematics?topic=schematics-workspace-setup&interface=ui#create-workspace_ui).
      */
     type?: string;
     /** Uninstall script name. */
@@ -7329,15 +9319,25 @@ namespace SchematicsV1 {
     variablestore?: WorkspaceVariableResponse[];
   }
 
+  /** The content of the Terraform statefile (`terraform.tfstate`). */
+  export interface TemplateStateStore {
+    version?: number;
+    terraform_version?: string;
+    serial?: number;
+    lineage?: string;
+    modules?: JsonObject[];
+  }
+
   /** Information about the input variables that are declared in the template that your workspace points to. */
   export interface TemplateValues {
+    /** Information about workspace variable metadata. */
     values_metadata?: JsonObject[];
   }
 
   /** Inputs for running a Terraform command on the workspace. */
   export interface TerraformCommand {
     /** You must provide the command to execute. Supported commands are `show`,`taint`, `untaint`, `state`,
-     *  `import`, `output`.
+     *  `import`, `output`, `drift`.
      */
     command?: string;
     /** The required address parameters for the command name. You can send the option flag and address parameter in
@@ -7383,59 +9383,79 @@ namespace SchematicsV1 {
      *  supported by Schematics.
      */
     env_values?: JsonObject[];
+    /** A list of environment variables that you want to apply during the execution of a bash script or Terraform
+     *  job. This field must be provided as a list of key-value pairs, for example, **TF_LOG=debug**. Each entry will be
+     *  a map with one entry where `key is the environment variable name and value is value`. You can define environment
+     *  variables for IBM Cloud catalog offerings that are provisioned by using a bash script. See [example to use
+     *  special environment
+     *  variable](https://cloud.ibm.com/docs/schematics?topic=schematics-set-parallelism#parallelism-example)  that are
+     *  supported by Schematics.
+     */
+    env_values_map?: EnvVariableRequestMap[];
     /** User values. */
     values?: string;
     /** Information about the input variables that your template uses. */
     variablestore?: WorkspaceVariableResponse[];
   }
 
-  /** User editable variable data & system generated reference to value. */
+  /** User editable variable data and system generated reference to the value. */
   export interface VariableData {
-    /** Name of the variable. */
+    /** The name of the variable. For example, `name = "inventory username"`. */
     name?: string;
-    /** Value for the variable or reference to the value. */
+    /** The value for the variable or reference to the value. For example, `value = "<provide your ssh_key_value
+     *  with \n>"`. **Note** The SSH key should contain `\n` at the end of the key details in case of command line or
+     *  API calls.
+     */
     value?: string;
-    /** User editable metadata for the variables. */
+    /** True, will ignore the data in the value attribute, instead the data in metadata.default_value will be used. */
+    use_default?: boolean;
+    /** An user editable metadata for the variables. */
     metadata?: VariableMetadata;
-    /** Reference link to the variable value By default the expression will point to self.value. */
+    /** The reference link to the variable value By default the expression points to `$self.value`. */
     link?: string;
   }
 
-  /** User editable metadata for the variables. */
+  /** An user editable metadata for the variables. */
   export interface VariableMetadata {
     /** Type of the variable. */
     type?: string;
-    /** List of aliases for the variable name. */
+    /** The list of aliases for the variable name. */
     aliases?: string[];
-    /** Description of the meta data. */
+    /** The description of the meta data. */
     description?: string;
-    /** Default value for the variable, if the override value is not specified. */
+    /** Cloud data type of the variable. eg. resource_group_id, region, vpc_id. */
+    cloud_data_type?: string;
+    /** Default value for the variable only if the override value is not specified. */
     default_value?: string;
+    /** The status of the link. */
+    link_status?: string;
     /** Is the variable secure or sensitive ?. */
     secure?: boolean;
     /** Is the variable readonly ?. */
     immutable?: boolean;
-    /** If true, the variable will not be displayed on UI or CLI. */
+    /** If **true**, the variable is not displayed on UI or Command line. */
     hidden?: boolean;
-    /** List of possible values for this variable.  If type is integer or date, then the array of string will be
-     *  converted to array of integers or date during runtime.
+    /** If the variable required?. */
+    required?: boolean;
+    /** The list of possible values for this variable.  If type is **integer** or **date**, then the array of string
+     *  is  converted to array of integers or date during the runtime.
      */
     options?: string[];
-    /** Minimum value of the variable. Applicable for integer type. */
+    /** The minimum value of the variable. Applicable for the integer type. */
     min_value?: number;
-    /** Maximum value of the variable. Applicable for integer type. */
+    /** The maximum value of the variable. Applicable for the integer type. */
     max_value?: number;
-    /** Minimum length of the variable value. Applicable for string type. */
+    /** The minimum length of the variable value. Applicable for the string type. */
     min_length?: number;
-    /** Maximum length of the variable value. Applicable for string type. */
+    /** The maximum length of the variable value. Applicable for the string type. */
     max_length?: number;
-    /** Regex for the variable value. */
+    /** The regex for the variable value. */
     matches?: string;
-    /** Relative position of this variable in a list. */
+    /** The relative position of this variable in a list. */
     position?: number;
-    /** Display name of the group this variable belongs to. */
+    /** The display name of the group this variable belongs to. */
     group_by?: string;
-    /** Source of this meta-data. */
+    /** The source of this meta-data. */
     source?: string;
   }
 
@@ -7482,7 +9502,6 @@ namespace SchematicsV1 {
      */
     message?: string[];
     /** The type of actovoty or job that ran against your workspace.
-     *
      *   * **APPLY**: The apply job was created when you used the `PUT /v1/workspaces/{id}/apply` API to apply a
      *  Terraform template in IBM Cloud.
      *   * **DESTROY**: The destroy job was created when you used the `DELETE /v1/workspaces/{id}/destroy` API to remove
@@ -7496,14 +9515,11 @@ namespace SchematicsV1 {
     /** The user ID who initiated the job. */
     performed_by?: string;
     /** The status of your activity or job. To retrieve the URL to your job logs, use the GET
-     *  /v1/workspaces/{id}/actions/{action_id}/logs API.
-     *
-     *  * **COMPLETED**: The job completed successfully.
-     *  * **CREATED**: The job was created, but the provisioning, modification, or removal of IBM Cloud resources has
-     *  not started yet.
-     *  * **FAILED**: An error occurred during the plan, apply, or destroy job. Use the job ID to retrieve the URL to
-     *  the log files for your job.
-     *  * **IN PROGRESS**: The job is in progress. You can use the log_url to access the logs.
+     *  /v1/workspaces/{id}/actions/{action_id}/logs API. * **COMPLETED**: The job completed successfully. *
+     *  **CREATED**: The job was created, but the provisioning, modification, or removal of IBM Cloud resources has not
+     *  started yet. * **FAILED**: An error occurred during the plan, apply, or destroy job. Use the job ID to retrieve
+     *  the URL to the log files for your job. * **IN PROGRESS**: The job is in progress. You can use the log_url to
+     *  access the logs.
      */
     status?: string;
     /** List of template activities. */
@@ -7540,7 +9556,6 @@ namespace SchematicsV1 {
     /** The ID of the activity or job that ran against your workspace. */
     action_id?: string;
     /** The type of actovoty or job that ran against your workspace.
-     *
      *   * **APPLY**: The apply job was created when you used the `PUT /v1/workspaces/{id}/apply` API to apply a
      *  Terraform template in IBM Cloud.
      *   * **DESTROY**: The destroy job was created when you used the `DELETE /v1/workspaces/{id}/destroy` API to remove
@@ -7590,14 +9605,11 @@ namespace SchematicsV1 {
     /** Job start time. */
     start_time?: string;
     /** The status of your activity or job. To retrieve the URL to your job logs, use the GET
-     *  /v1/workspaces/{id}/actions/{action_id}/logs API.
-     *
-     *  * **COMPLETED**: The job completed successfully.
-     *  * **CREATED**: The job was created, but the provisioning, modification, or removal of IBM Cloud resources has
-     *  not started yet.
-     *  * **FAILED**: An error occurred during the plan, apply, or destroy job. Use the job ID to retrieve the URL to
-     *  the log files for your job.
-     *  * **IN PROGRESS**: The job is in progress. You can use the log_url to access the logs.
+     *  /v1/workspaces/{id}/actions/{action_id}/logs API. * **COMPLETED**: The job completed successfully. *
+     *  **CREATED**: The job was created, but the provisioning, modification, or removal of IBM Cloud resources has not
+     *  started yet. * **FAILED**: An error occurred during the plan, apply, or destroy job. Use the job ID to retrieve
+     *  the URL to the log files for your job. * **IN PROGRESS**: The job is in progress. You can use the log_url to
+     *  access the logs.
      */
     status?: string;
     /** The ID that was assigned to your Terraform template or IBM Cloud catalog software template. */
@@ -7616,15 +9628,15 @@ namespace SchematicsV1 {
     template_type?: string;
   }
 
-  /** Response after successfully initiating the bulk job to delete multiple workspaces. */
+  /** The response after successfully initiating the bulk job to delete multiple workspaces. */
   export interface WorkspaceBulkDeleteResponse {
-    /** Workspace deletion job name. */
+    /** The workspace deletion job name. */
     job?: string;
-    /** Workspace deletion job id. */
+    /** The workspace deletion job id. */
     job_id?: string;
   }
 
-  /** Response from the workspace bulk job status. */
+  /** The response from the workspace bulk job status. */
   export interface WorkspaceJobResponse {
     /** Status of the workspace bulk job. */
     job_status?: WorkspaceJobStatusType;
@@ -7644,7 +9656,7 @@ namespace SchematicsV1 {
 
   /** Workspace details. */
   export interface WorkspaceResponse {
-    /** List of applied shared dataset ID. */
+    /** Deprecated: List of applied shared dataset ID. */
     applied_shareddata_ids?: string[];
     /** Information about the software template that you chose from the IBM Cloud catalog. This information is
      *  returned for IBM Cloud catalog offerings only.
@@ -7656,6 +9668,8 @@ namespace SchematicsV1 {
     created_by?: string;
     /** The workspace CRN. */
     crn?: string;
+    /** Workspace dependencies. */
+    dependencies?: Dependencies;
     /** The description of the workspace. */
     description?: string;
     /** The unique identifier of the workspace. */
@@ -7675,33 +9689,24 @@ namespace SchematicsV1 {
      */
     shared_data?: SharedTargetDataResponse;
     /** The status of the workspace.
-     *
      *    **Active**: After you successfully ran your infrastructure code by applying your Terraform execution plan, the
      *  state of your workspace changes to `Active`.
-     *
      *    **Connecting**: Schematics tries to connect to the template in your source repo. If successfully connected,
      *  the template is downloaded and metadata, such as input parameters, is extracted. After the template is
      *  downloaded, the state of the workspace changes to `Scanning`.
-     *
      *    **Draft**: The workspace is created without a reference to a GitHub or GitLab repository.
-     *
      *    **Failed**: If errors occur during the execution of your infrastructure code in IBM Cloud Schematics, your
      *  workspace status is set to `Failed`.
-     *
      *    **Inactive**: The Terraform template was scanned successfully and the workspace creation is complete. You can
      *  now start running Schematics plan and apply jobs to provision the IBM Cloud resources that you specified in your
      *  template. If you have an `Active` workspace and decide to remove all your resources, your workspace is set to
      *  `Inactive` after all your resources are removed.
-     *
      *    **In progress**: When you instruct IBM Cloud Schematics to run your infrastructure code by applying your
      *  Terraform execution plan, the status of our workspace changes to `In progress`.
-     *
      *    **Scanning**: The download of the Terraform template is complete and vulnerability scanning started. If the
      *  scan is successful, the workspace state changes to `Inactive`. If errors in your template are found, the state
      *  changes to `Template Error`.
-     *
      *    **Stopped**: The Schematics plan, apply, or destroy job was cancelled manually.
-     *
      *    **Template Error**: The Schematics template contains errors and cannot be processed.
      */
     status?: string;
@@ -7719,10 +9724,20 @@ namespace SchematicsV1 {
     updated_at?: string;
     /** The user ID that updated the workspace. */
     updated_by?: string;
+    /** The associate cart order ID. */
+    cart_id?: string;
+    /** Name of the last Action performed on workspace. */
+    last_action_name?: string;
+    /** ID of last Activity performed. */
+    last_activity_id?: string;
+    /** Last job details. */
+    last_job?: LastJob;
     /** Response that indicate the status of the workspace as either frozen or locked. */
     workspace_status?: WorkspaceStatusResponse;
     /** Information about the last job that ran against the workspace. -. */
     workspace_status_msg?: WorkspaceStatusMessage;
+    /** Agent name, Agent id and associated policy ID information. */
+    agent?: AgentInfo;
   }
 
   /** List of workspaces. */

--- a/test/unit/schematics.v1.test.js
+++ b/test/unit/schematics.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,25 +32,36 @@ const {
 
 const schematicsServiceOptions = {
   authenticator: new NoAuthAuthenticator(),
-  url: 'https://schematics-dev.containers.appdomain.cloud',
+  url: 'https://schematics.cloud.ibm.com',
 };
 
 const schematicsService = new SchematicsV1(schematicsServiceOptions);
 
-// dont actually create a request
-const createRequestMock = jest.spyOn(schematicsService, 'createRequest');
-createRequestMock.mockImplementation(() => Promise.resolve());
+let createRequestMock = null;
+function mock_createRequest() {
+  if (!createRequestMock) {
+    createRequestMock = jest.spyOn(schematicsService, 'createRequest');
+    createRequestMock.mockImplementation(() => Promise.resolve());
+  }
+}
 
 // dont actually construct an authenticator
 const getAuthenticatorMock = jest.spyOn(core, 'getAuthenticatorFromEnvironment');
 getAuthenticatorMock.mockImplementation(() => new NoAuthAuthenticator());
 
-afterEach(() => {
-  createRequestMock.mockClear();
-  getAuthenticatorMock.mockClear();
-});
-
 describe('SchematicsV1', () => {
+
+  beforeEach(() => {
+    mock_createRequest();
+  });
+
+  afterEach(() => {
+    if (createRequestMock) {
+      createRequestMock.mockClear();
+    }
+    getAuthenticatorMock.mockClear();
+  });
+  
   describe('the newInstance method', () => {
     test('should use defaults when options not provided', () => {
       const testInstance = SchematicsV1.newInstance();
@@ -78,6 +89,7 @@ describe('SchematicsV1', () => {
       expect(testInstance).toBeInstanceOf(SchematicsV1);
     });
   });
+
   describe('the constructor', () => {
     test('use user-given service url', () => {
       const options = {
@@ -100,13 +112,14 @@ describe('SchematicsV1', () => {
       expect(testInstance.baseOptions.serviceUrl).toBe(SchematicsV1.DEFAULT_SERVICE_URL);
     });
   });
+
   describe('listSchematicsLocation', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listSchematicsLocationTest() {
         // Construct the params object for operation listSchematicsLocation
-        const params = {};
+        const listSchematicsLocationParams = {};
 
-        const listSchematicsLocationResult = schematicsService.listSchematicsLocation(params);
+        const listSchematicsLocationResult = schematicsService.listSchematicsLocation(listSchematicsLocationParams);
 
         // all methods should return a Promise
         expectToBePromise(listSchematicsLocationResult);
@@ -114,26 +127,41 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/locations', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/locations', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listSchematicsLocationTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listSchematicsLocationTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listSchematicsLocationTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listSchematicsLocationParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listSchematicsLocation(params);
+        schematicsService.listSchematicsLocation(listSchematicsLocationParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -144,13 +172,14 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('listLocations', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listLocationsTest() {
         // Construct the params object for operation listLocations
-        const params = {};
+        const listLocationsParams = {};
 
-        const listLocationsResult = schematicsService.listLocations(params);
+        const listLocationsResult = schematicsService.listLocations(listLocationsParams);
 
         // all methods should return a Promise
         expectToBePromise(listLocationsResult);
@@ -158,26 +187,41 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/locations', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/locations', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listLocationsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listLocationsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listLocationsTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listLocationsParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listLocations(params);
+        schematicsService.listLocations(listLocationsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -188,13 +232,14 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('listResourceGroup', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listResourceGroupTest() {
         // Construct the params object for operation listResourceGroup
-        const params = {};
+        const listResourceGroupParams = {};
 
-        const listResourceGroupResult = schematicsService.listResourceGroup(params);
+        const listResourceGroupResult = schematicsService.listResourceGroup(listResourceGroupParams);
 
         // all methods should return a Promise
         expectToBePromise(listResourceGroupResult);
@@ -202,26 +247,41 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/resource_groups', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/resource_groups', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listResourceGroupTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listResourceGroupTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listResourceGroupTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listResourceGroupParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listResourceGroup(params);
+        schematicsService.listResourceGroup(listResourceGroupParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -232,13 +292,14 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('getSchematicsVersion', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getSchematicsVersionTest() {
         // Construct the params object for operation getSchematicsVersion
-        const params = {};
+        const getSchematicsVersionParams = {};
 
-        const getSchematicsVersionResult = schematicsService.getSchematicsVersion(params);
+        const getSchematicsVersionResult = schematicsService.getSchematicsVersion(getSchematicsVersionParams);
 
         // all methods should return a Promise
         expectToBePromise(getSchematicsVersionResult);
@@ -246,26 +307,41 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/version', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/version', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getSchematicsVersionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getSchematicsVersionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getSchematicsVersionTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getSchematicsVersionParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.getSchematicsVersion(params);
+        schematicsService.getSchematicsVersion(getSchematicsVersionParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -276,12 +352,13 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('processTemplateMetaData', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
-      // ExternalSourceGit
-      const externalSourceGitModel = {
+      // GitSource
+      const gitSourceModel = {
         computed_git_repo_url: 'testString',
         git_repo_url: 'testString',
         git_token: 'testString',
@@ -290,38 +367,44 @@ describe('SchematicsV1', () => {
         git_branch: 'testString',
       };
 
-      // ExternalSourceCatalog
-      const externalSourceCatalogModel = {
+      // CatalogSource
+      const catalogSourceModel = {
         catalog_name: 'testString',
+        catalog_id: 'testString',
         offering_name: 'testString',
         offering_version: 'testString',
         offering_kind: 'testString',
+        offering_target_kind: 'testString',
         offering_id: 'testString',
         offering_version_id: 'testString',
+        offering_version_flavour_name: 'testString',
         offering_repo_url: 'testString',
-      };
-
-      // ExternalSourceCosBucket
-      const externalSourceCosBucketModel = {
-        cos_bucket_url: 'testString',
+        offering_provisioner_working_directory: 'testString',
+        dry_run: true,
+        owning_account: 'testString',
+        item_icon_url: 'testString',
+        item_id: 'testString',
+        item_name: 'testString',
+        item_readme_url: 'testString',
+        item_url: 'testString',
+        launch_url: 'testString',
       };
 
       // ExternalSource
       const externalSourceModel = {
         source_type: 'local',
-        git: externalSourceGitModel,
-        catalog: externalSourceCatalogModel,
-        cos_bucket: externalSourceCosBucketModel,
+        git: gitSourceModel,
+        catalog: catalogSourceModel,
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __processTemplateMetaDataTest() {
         // Construct the params object for operation processTemplateMetaData
         const templateType = 'testString';
         const source = externalSourceModel;
         const region = 'testString';
         const sourceType = 'local';
         const xGithubToken = 'testString';
-        const params = {
+        const processTemplateMetaDataParams = {
           templateType,
           source,
           region,
@@ -329,7 +412,7 @@ describe('SchematicsV1', () => {
           xGithubToken,
         };
 
-        const processTemplateMetaDataResult = schematicsService.processTemplateMetaData(params);
+        const processTemplateMetaDataResult = schematicsService.processTemplateMetaData(processTemplateMetaDataParams);
 
         // all methods should return a Promise
         expectToBePromise(processTemplateMetaDataResult);
@@ -337,17 +420,32 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/template_metadata_processor', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v2/template_metadata_processor', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'X-Github-token', xGithubToken);
-        expect(options.body.template_type).toEqual(templateType);
-        expect(options.body.source).toEqual(source);
-        expect(options.body.region).toEqual(region);
-        expect(options.body.source_type).toEqual(sourceType);
+        expect(mockRequestOptions.body.template_type).toEqual(templateType);
+        expect(mockRequestOptions.body.source).toEqual(source);
+        expect(mockRequestOptions.body.region).toEqual(region);
+        expect(mockRequestOptions.body.source_type).toEqual(sourceType);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __processTemplateMetaDataTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __processTemplateMetaDataTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __processTemplateMetaDataTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -356,7 +454,7 @@ describe('SchematicsV1', () => {
         const source = externalSourceModel;
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const processTemplateMetaDataParams = {
           templateType,
           source,
           headers: {
@@ -365,13 +463,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.processTemplateMetaData(params);
+        schematicsService.processTemplateMetaData(processTemplateMetaDataParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.processTemplateMetaData({});
@@ -380,32 +478,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const processTemplateMetaDataPromise = schematicsService.processTemplateMetaData();
-        expectToBePromise(processTemplateMetaDataPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.processTemplateMetaData();
+        } catch (e) {
+          err = e;
+        }
 
-        processTemplateMetaDataPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('listWorkspaces', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listWorkspacesTest() {
         // Construct the params object for operation listWorkspaces
         const offset = 0;
         const limit = 1;
-        const params = {
+        const profile = 'ids';
+        const listWorkspacesParams = {
           offset,
           limit,
+          profile,
         };
 
-        const listWorkspacesResult = schematicsService.listWorkspaces(params);
+        const listWorkspacesResult = schematicsService.listWorkspaces(listWorkspacesParams);
 
         // all methods should return a Promise
         expectToBePromise(listWorkspacesResult);
@@ -413,28 +514,44 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.offset).toEqual(offset);
-        expect(options.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listWorkspacesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listWorkspacesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listWorkspacesTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listWorkspacesParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listWorkspaces(params);
+        schematicsService.listWorkspaces(listWorkspacesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -445,9 +562,17 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('createWorkspace', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
+
+      // ServiceExtensions
+      const serviceExtensionsModel = {
+        name: 'flavor',
+        value: 'standard',
+        type: 'string',
+      };
 
       // CatalogRef
       const catalogRefModel = {
@@ -460,6 +585,13 @@ describe('SchematicsV1', () => {
         item_url: 'testString',
         launch_url: 'testString',
         offering_version: 'testString',
+        service_extensions: [serviceExtensionsModel],
+      };
+
+      // Dependencies
+      const dependenciesModel = {
+        parents: ['testString'],
+        children: ['testString'],
       };
 
       // SharedTargetData
@@ -476,6 +608,29 @@ describe('SchematicsV1', () => {
         worker_machine_type: 'testString',
       };
 
+      // EnvironmentValuesMetadata
+      const environmentValuesMetadataModel = {
+        hidden: true,
+        name: 'testString',
+        secure: true,
+      };
+
+      // InjectTerraformTemplateInnerTftParametersItem
+      const injectTerraformTemplateInnerTftParametersItemModel = {
+        name: 'testString',
+        value: 'testString',
+      };
+
+      // InjectTerraformTemplateInner
+      const injectTerraformTemplateInnerModel = {
+        tft_git_url: 'testString',
+        tft_git_token: 'testString',
+        tft_prefix: 'testString',
+        injection_type: 'testString',
+        tft_name: 'testString',
+        tft_parameters: [injectTerraformTemplateInnerTftParametersItemModel],
+      };
+
       // WorkspaceVariableRequest
       const workspaceVariableRequestModel = {
         description: 'testString',
@@ -489,9 +644,11 @@ describe('SchematicsV1', () => {
       // TemplateSourceDataRequest
       const templateSourceDataRequestModel = {
         env_values: [{ foo: 'bar' }],
+        env_values_metadata: [environmentValuesMetadataModel],
         folder: 'testString',
         compact: true,
         init_state_file: 'testString',
+        injectors: [injectTerraformTemplateInnerModel],
         type: 'testString',
         uninstall_script_name: 'testString',
         values: 'testString',
@@ -518,10 +675,11 @@ describe('SchematicsV1', () => {
         locked_time: '2019-01-01T12:00:00.000Z',
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __createWorkspaceTest() {
         // Construct the params object for operation createWorkspace
         const appliedShareddataIds = ['testString'];
         const catalogRef = catalogRefModel;
+        const dependencies = dependenciesModel;
         const description = 'testString';
         const location = 'testString';
         const name = 'testString';
@@ -533,10 +691,12 @@ describe('SchematicsV1', () => {
         const templateRepo = templateRepoRequestModel;
         const type = ['testString'];
         const workspaceStatus = workspaceStatusRequestModel;
+        const agentId = 'testString';
         const xGithubToken = 'testString';
-        const params = {
+        const createWorkspaceParams = {
           appliedShareddataIds,
           catalogRef,
+          dependencies,
           description,
           location,
           name,
@@ -548,10 +708,11 @@ describe('SchematicsV1', () => {
           templateRepo,
           type,
           workspaceStatus,
+          agentId,
           xGithubToken,
         };
 
-        const createWorkspaceResult = schematicsService.createWorkspace(params);
+        const createWorkspaceResult = schematicsService.createWorkspace(createWorkspaceParams);
 
         // all methods should return a Promise
         expectToBePromise(createWorkspaceResult);
@@ -559,40 +720,57 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'X-Github-token', xGithubToken);
-        expect(options.body.applied_shareddata_ids).toEqual(appliedShareddataIds);
-        expect(options.body.catalog_ref).toEqual(catalogRef);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.resource_group).toEqual(resourceGroup);
-        expect(options.body.shared_data).toEqual(sharedData);
-        expect(options.body.tags).toEqual(tags);
-        expect(options.body.template_data).toEqual(templateData);
-        expect(options.body.template_ref).toEqual(templateRef);
-        expect(options.body.template_repo).toEqual(templateRepo);
-        expect(options.body.type).toEqual(type);
-        expect(options.body.workspace_status).toEqual(workspaceStatus);
+        expect(mockRequestOptions.body.applied_shareddata_ids).toEqual(appliedShareddataIds);
+        expect(mockRequestOptions.body.catalog_ref).toEqual(catalogRef);
+        expect(mockRequestOptions.body.dependencies).toEqual(dependencies);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.shared_data).toEqual(sharedData);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.template_data).toEqual(templateData);
+        expect(mockRequestOptions.body.template_ref).toEqual(templateRef);
+        expect(mockRequestOptions.body.template_repo).toEqual(templateRepo);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.workspace_status).toEqual(workspaceStatus);
+        expect(mockRequestOptions.body.agent_id).toEqual(agentId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createWorkspaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __createWorkspaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __createWorkspaceTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createWorkspaceParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.createWorkspace(params);
+        schematicsService.createWorkspace(createWorkspaceParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -603,16 +781,17 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('getWorkspace', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceTest() {
         // Construct the params object for operation getWorkspace
         const wId = 'testString';
-        const params = {
+        const getWorkspaceParams = {
           wId,
         };
 
-        const getWorkspaceResult = schematicsService.getWorkspace(params);
+        const getWorkspaceResult = schematicsService.getWorkspace(getWorkspaceParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceResult);
@@ -620,13 +799,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -634,7 +828,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -642,13 +836,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspace(params);
+        schematicsService.getWorkspace(getWorkspaceParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspace({});
@@ -657,23 +851,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspacePromise = schematicsService.getWorkspace();
-        expectToBePromise(getWorkspacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspace();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspacePromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('replaceWorkspace', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
+
+      // ServiceExtensions
+      const serviceExtensionsModel = {
+        name: 'flavor',
+        value: 'standard',
+        type: 'string',
+      };
 
       // CatalogRef
       const catalogRefModel = {
@@ -686,6 +888,13 @@ describe('SchematicsV1', () => {
         item_url: 'testString',
         launch_url: 'testString',
         offering_version: 'testString',
+        service_extensions: [serviceExtensionsModel],
+      };
+
+      // Dependencies
+      const dependenciesModel = {
+        parents: ['testString'],
+        children: ['testString'],
       };
 
       // SharedTargetData
@@ -702,6 +911,29 @@ describe('SchematicsV1', () => {
         worker_machine_type: 'testString',
       };
 
+      // EnvironmentValuesMetadata
+      const environmentValuesMetadataModel = {
+        hidden: true,
+        name: 'testString',
+        secure: true,
+      };
+
+      // InjectTerraformTemplateInnerTftParametersItem
+      const injectTerraformTemplateInnerTftParametersItemModel = {
+        name: 'testString',
+        value: 'testString',
+      };
+
+      // InjectTerraformTemplateInner
+      const injectTerraformTemplateInnerModel = {
+        tft_git_url: 'testString',
+        tft_git_token: 'testString',
+        tft_prefix: 'testString',
+        injection_type: 'testString',
+        tft_name: 'testString',
+        tft_parameters: [injectTerraformTemplateInnerTftParametersItemModel],
+      };
+
       // WorkspaceVariableRequest
       const workspaceVariableRequestModel = {
         description: 'testString',
@@ -715,9 +947,11 @@ describe('SchematicsV1', () => {
       // TemplateSourceDataRequest
       const templateSourceDataRequestModel = {
         env_values: [{ foo: 'bar' }],
+        env_values_metadata: [environmentValuesMetadataModel],
         folder: 'testString',
         compact: true,
         init_state_file: 'testString',
+        injectors: [injectTerraformTemplateInnerModel],
         type: 'testString',
         uninstall_script_name: 'testString',
         values: 'testString',
@@ -750,11 +984,12 @@ describe('SchematicsV1', () => {
         status_msg: 'testString',
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __replaceWorkspaceTest() {
         // Construct the params object for operation replaceWorkspace
         const wId = 'testString';
         const catalogRef = catalogRefModel;
         const description = 'testString';
+        const dependencies = dependenciesModel;
         const name = 'testString';
         const sharedData = sharedTargetDataModel;
         const tags = ['testString'];
@@ -763,10 +998,13 @@ describe('SchematicsV1', () => {
         const type = ['testString'];
         const workspaceStatus = workspaceStatusUpdateRequestModel;
         const workspaceStatusMsg = workspaceStatusMessageModel;
-        const params = {
+        const agentId = 'testString';
+        const xGithubToken = 'testString';
+        const replaceWorkspaceParams = {
           wId,
           catalogRef,
           description,
+          dependencies,
           name,
           sharedData,
           tags,
@@ -775,9 +1013,11 @@ describe('SchematicsV1', () => {
           type,
           workspaceStatus,
           workspaceStatusMsg,
+          agentId,
+          xGithubToken,
         };
 
-        const replaceWorkspaceResult = schematicsService.replaceWorkspace(params);
+        const replaceWorkspaceResult = schematicsService.replaceWorkspace(replaceWorkspaceParams);
 
         // all methods should return a Promise
         expectToBePromise(replaceWorkspaceResult);
@@ -785,23 +1025,41 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.catalog_ref).toEqual(catalogRef);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.shared_data).toEqual(sharedData);
-        expect(options.body.tags).toEqual(tags);
-        expect(options.body.template_data).toEqual(templateData);
-        expect(options.body.template_repo).toEqual(templateRepo);
-        expect(options.body.type).toEqual(type);
-        expect(options.body.workspace_status).toEqual(workspaceStatus);
-        expect(options.body.workspace_status_msg).toEqual(workspaceStatusMsg);
-        expect(options.path.w_id).toEqual(wId);
+        checkUserHeader(createRequestMock, 'X-Github-token', xGithubToken);
+        expect(mockRequestOptions.body.catalog_ref).toEqual(catalogRef);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.dependencies).toEqual(dependencies);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.shared_data).toEqual(sharedData);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.template_data).toEqual(templateData);
+        expect(mockRequestOptions.body.template_repo).toEqual(templateRepo);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.workspace_status).toEqual(workspaceStatus);
+        expect(mockRequestOptions.body.workspace_status_msg).toEqual(workspaceStatusMsg);
+        expect(mockRequestOptions.body.agent_id).toEqual(agentId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __replaceWorkspaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __replaceWorkspaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __replaceWorkspaceTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -809,7 +1067,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const replaceWorkspaceParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -817,13 +1075,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.replaceWorkspace(params);
+        schematicsService.replaceWorkspace(replaceWorkspaceParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.replaceWorkspace({});
@@ -832,34 +1090,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const replaceWorkspacePromise = schematicsService.replaceWorkspace();
-        expectToBePromise(replaceWorkspacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.replaceWorkspace();
+        } catch (e) {
+          err = e;
+        }
 
-        replaceWorkspacePromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('deleteWorkspace', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __deleteWorkspaceTest() {
         // Construct the params object for operation deleteWorkspace
         const refreshToken = 'testString';
         const wId = 'testString';
         const destroyResources = 'testString';
-        const params = {
+        const deleteWorkspaceParams = {
           refreshToken,
           wId,
           destroyResources,
         };
 
-        const deleteWorkspaceResult = schematicsService.deleteWorkspace(params);
+        const deleteWorkspaceResult = schematicsService.deleteWorkspace(deleteWorkspaceParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteWorkspaceResult);
@@ -867,15 +1126,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}', 'DELETE');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}', 'DELETE');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
-        expect(options.qs.destroy_resources).toEqual(destroyResources);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.qs.destroy_resources).toEqual(destroyResources);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteWorkspaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteWorkspaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteWorkspaceTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -884,7 +1158,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deleteWorkspaceParams = {
           refreshToken,
           wId,
           headers: {
@@ -893,13 +1167,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.deleteWorkspace(params);
+        schematicsService.deleteWorkspace(deleteWorkspaceParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.deleteWorkspace({});
@@ -908,23 +1182,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const deleteWorkspacePromise = schematicsService.deleteWorkspace();
-        expectToBePromise(deleteWorkspacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.deleteWorkspace();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteWorkspacePromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('updateWorkspace', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
+
+      // ServiceExtensions
+      const serviceExtensionsModel = {
+        name: 'flavor',
+        value: 'standard',
+        type: 'string',
+      };
 
       // CatalogRef
       const catalogRefModel = {
@@ -937,6 +1219,13 @@ describe('SchematicsV1', () => {
         item_url: 'testString',
         launch_url: 'testString',
         offering_version: 'testString',
+        service_extensions: [serviceExtensionsModel],
+      };
+
+      // Dependencies
+      const dependenciesModel = {
+        parents: ['testString'],
+        children: ['testString'],
       };
 
       // SharedTargetData
@@ -953,6 +1242,29 @@ describe('SchematicsV1', () => {
         worker_machine_type: 'testString',
       };
 
+      // EnvironmentValuesMetadata
+      const environmentValuesMetadataModel = {
+        hidden: true,
+        name: 'testString',
+        secure: true,
+      };
+
+      // InjectTerraformTemplateInnerTftParametersItem
+      const injectTerraformTemplateInnerTftParametersItemModel = {
+        name: 'testString',
+        value: 'testString',
+      };
+
+      // InjectTerraformTemplateInner
+      const injectTerraformTemplateInnerModel = {
+        tft_git_url: 'testString',
+        tft_git_token: 'testString',
+        tft_prefix: 'testString',
+        injection_type: 'testString',
+        tft_name: 'testString',
+        tft_parameters: [injectTerraformTemplateInnerTftParametersItemModel],
+      };
+
       // WorkspaceVariableRequest
       const workspaceVariableRequestModel = {
         description: 'testString',
@@ -966,9 +1278,11 @@ describe('SchematicsV1', () => {
       // TemplateSourceDataRequest
       const templateSourceDataRequestModel = {
         env_values: [{ foo: 'bar' }],
+        env_values_metadata: [environmentValuesMetadataModel],
         folder: 'testString',
         compact: true,
         init_state_file: 'testString',
+        injectors: [injectTerraformTemplateInnerModel],
         type: 'testString',
         uninstall_script_name: 'testString',
         values: 'testString',
@@ -1001,11 +1315,12 @@ describe('SchematicsV1', () => {
         status_msg: 'testString',
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __updateWorkspaceTest() {
         // Construct the params object for operation updateWorkspace
         const wId = 'testString';
         const catalogRef = catalogRefModel;
         const description = 'testString';
+        const dependencies = dependenciesModel;
         const name = 'testString';
         const sharedData = sharedTargetDataModel;
         const tags = ['testString'];
@@ -1014,10 +1329,12 @@ describe('SchematicsV1', () => {
         const type = ['testString'];
         const workspaceStatus = workspaceStatusUpdateRequestModel;
         const workspaceStatusMsg = workspaceStatusMessageModel;
-        const params = {
+        const agentId = 'testString';
+        const updateWorkspaceParams = {
           wId,
           catalogRef,
           description,
+          dependencies,
           name,
           sharedData,
           tags,
@@ -1026,9 +1343,10 @@ describe('SchematicsV1', () => {
           type,
           workspaceStatus,
           workspaceStatusMsg,
+          agentId,
         };
 
-        const updateWorkspaceResult = schematicsService.updateWorkspace(params);
+        const updateWorkspaceResult = schematicsService.updateWorkspace(updateWorkspaceParams);
 
         // all methods should return a Promise
         expectToBePromise(updateWorkspaceResult);
@@ -1036,23 +1354,40 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}', 'PATCH');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}', 'PATCH');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.catalog_ref).toEqual(catalogRef);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.shared_data).toEqual(sharedData);
-        expect(options.body.tags).toEqual(tags);
-        expect(options.body.template_data).toEqual(templateData);
-        expect(options.body.template_repo).toEqual(templateRepo);
-        expect(options.body.type).toEqual(type);
-        expect(options.body.workspace_status).toEqual(workspaceStatus);
-        expect(options.body.workspace_status_msg).toEqual(workspaceStatusMsg);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.body.catalog_ref).toEqual(catalogRef);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.dependencies).toEqual(dependencies);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.shared_data).toEqual(sharedData);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.template_data).toEqual(templateData);
+        expect(mockRequestOptions.body.template_repo).toEqual(templateRepo);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.workspace_status).toEqual(workspaceStatus);
+        expect(mockRequestOptions.body.workspace_status_msg).toEqual(workspaceStatusMsg);
+        expect(mockRequestOptions.body.agent_id).toEqual(agentId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateWorkspaceTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __updateWorkspaceTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __updateWorkspaceTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1060,7 +1395,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const updateWorkspaceParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -1068,13 +1403,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.updateWorkspace(params);
+        schematicsService.updateWorkspace(updateWorkspaceParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.updateWorkspace({});
@@ -1083,34 +1418,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const updateWorkspacePromise = schematicsService.updateWorkspace();
-        expectToBePromise(updateWorkspacePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.updateWorkspace();
+        } catch (e) {
+          err = e;
+        }
 
-        updateWorkspacePromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceReadme', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceReadmeTest() {
         // Construct the params object for operation getWorkspaceReadme
         const wId = 'testString';
         const ref = 'testString';
         const formatted = 'markdown';
-        const params = {
+        const getWorkspaceReadmeParams = {
           wId,
           ref,
           formatted,
         };
 
-        const getWorkspaceReadmeResult = schematicsService.getWorkspaceReadme(params);
+        const getWorkspaceReadmeResult = schematicsService.getWorkspaceReadme(getWorkspaceReadmeParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceReadmeResult);
@@ -1118,15 +1454,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/templates/readme', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/templates/readme', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.ref).toEqual(ref);
-        expect(options.qs.formatted).toEqual(formatted);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.qs.ref).toEqual(ref);
+        expect(mockRequestOptions.qs.formatted).toEqual(formatted);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceReadmeTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceReadmeTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceReadmeTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1134,7 +1485,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceReadmeParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -1142,13 +1493,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceReadme(params);
+        schematicsService.getWorkspaceReadme(getWorkspaceReadmeParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceReadme({});
@@ -1157,36 +1508,37 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceReadmePromise = schematicsService.getWorkspaceReadme();
-        expectToBePromise(getWorkspaceReadmePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceReadme();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceReadmePromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('templateRepoUpload', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __templateRepoUploadTest() {
         // Construct the params object for operation templateRepoUpload
         const wId = 'testString';
         const tId = 'testString';
         const file = Buffer.from('This is a mock file.');
         const fileContentType = 'testString';
-        const params = {
+        const templateRepoUploadParams = {
           wId,
           tId,
           file,
           fileContentType,
         };
 
-        const templateRepoUploadResult = schematicsService.templateRepoUpload(params);
+        const templateRepoUploadResult = schematicsService.templateRepoUpload(templateRepoUploadParams);
 
         // all methods should return a Promise
         expectToBePromise(templateRepoUploadResult);
@@ -1194,20 +1546,31 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          options,
-          '/v1/workspaces/{w_id}/template_data/{t_id}/template_repo_upload',
-          'PUT'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/template_data/{t_id}/template_repo_upload', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'multipart/form-data';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.formData.file.data).toEqual(file);
-        expect(options.formData.file.contentType).toEqual(fileContentType);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.t_id).toEqual(tId);
+        expect(mockRequestOptions.formData.file.data).toEqual(file);
+        expect(mockRequestOptions.formData.file.contentType).toEqual(fileContentType);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.t_id).toEqual(tId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __templateRepoUploadTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __templateRepoUploadTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __templateRepoUploadTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1216,7 +1579,7 @@ describe('SchematicsV1', () => {
         const tId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const templateRepoUploadParams = {
           wId,
           tId,
           headers: {
@@ -1225,13 +1588,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.templateRepoUpload(params);
+        schematicsService.templateRepoUpload(templateRepoUploadParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.templateRepoUpload({});
@@ -1240,32 +1603,33 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const templateRepoUploadPromise = schematicsService.templateRepoUpload();
-        expectToBePromise(templateRepoUploadPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.templateRepoUpload();
+        } catch (e) {
+          err = e;
+        }
 
-        templateRepoUploadPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceInputs', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceInputsTest() {
         // Construct the params object for operation getWorkspaceInputs
         const wId = 'testString';
         const tId = 'testString';
-        const params = {
+        const getWorkspaceInputsParams = {
           wId,
           tId,
         };
 
-        const getWorkspaceInputsResult = schematicsService.getWorkspaceInputs(params);
+        const getWorkspaceInputsResult = schematicsService.getWorkspaceInputs(getWorkspaceInputsParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceInputsResult);
@@ -1273,14 +1637,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/template_data/{t_id}/values', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/template_data/{t_id}/values', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.t_id).toEqual(tId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.t_id).toEqual(tId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceInputsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceInputsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceInputsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1289,7 +1668,7 @@ describe('SchematicsV1', () => {
         const tId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceInputsParams = {
           wId,
           tId,
           headers: {
@@ -1298,13 +1677,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceInputs(params);
+        schematicsService.getWorkspaceInputs(getWorkspaceInputsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceInputs({});
@@ -1313,20 +1692,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceInputsPromise = schematicsService.getWorkspaceInputs();
-        expectToBePromise(getWorkspaceInputsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceInputs();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceInputsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('replaceWorkspaceInputs', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -1341,14 +1721,14 @@ describe('SchematicsV1', () => {
         value: 'testString',
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __replaceWorkspaceInputsTest() {
         // Construct the params object for operation replaceWorkspaceInputs
         const wId = 'testString';
         const tId = 'testString';
         const envValues = [{ foo: 'bar' }];
         const values = 'testString';
         const variablestore = [workspaceVariableRequestModel];
-        const params = {
+        const replaceWorkspaceInputsParams = {
           wId,
           tId,
           envValues,
@@ -1356,7 +1736,7 @@ describe('SchematicsV1', () => {
           variablestore,
         };
 
-        const replaceWorkspaceInputsResult = schematicsService.replaceWorkspaceInputs(params);
+        const replaceWorkspaceInputsResult = schematicsService.replaceWorkspaceInputs(replaceWorkspaceInputsParams);
 
         // all methods should return a Promise
         expectToBePromise(replaceWorkspaceInputsResult);
@@ -1364,17 +1744,32 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/template_data/{t_id}/values', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/template_data/{t_id}/values', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.env_values).toEqual(envValues);
-        expect(options.body.values).toEqual(values);
-        expect(options.body.variablestore).toEqual(variablestore);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.t_id).toEqual(tId);
+        expect(mockRequestOptions.body.env_values).toEqual(envValues);
+        expect(mockRequestOptions.body.values).toEqual(values);
+        expect(mockRequestOptions.body.variablestore).toEqual(variablestore);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.t_id).toEqual(tId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __replaceWorkspaceInputsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __replaceWorkspaceInputsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __replaceWorkspaceInputsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1383,7 +1778,7 @@ describe('SchematicsV1', () => {
         const tId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const replaceWorkspaceInputsParams = {
           wId,
           tId,
           headers: {
@@ -1392,13 +1787,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.replaceWorkspaceInputs(params);
+        schematicsService.replaceWorkspaceInputs(replaceWorkspaceInputsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.replaceWorkspaceInputs({});
@@ -1407,30 +1802,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const replaceWorkspaceInputsPromise = schematicsService.replaceWorkspaceInputs();
-        expectToBePromise(replaceWorkspaceInputsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.replaceWorkspaceInputs();
+        } catch (e) {
+          err = e;
+        }
 
-        replaceWorkspaceInputsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getAllWorkspaceInputs', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getAllWorkspaceInputsTest() {
         // Construct the params object for operation getAllWorkspaceInputs
         const wId = 'testString';
-        const params = {
+        const getAllWorkspaceInputsParams = {
           wId,
         };
 
-        const getAllWorkspaceInputsResult = schematicsService.getAllWorkspaceInputs(params);
+        const getAllWorkspaceInputsResult = schematicsService.getAllWorkspaceInputs(getAllWorkspaceInputsParams);
 
         // all methods should return a Promise
         expectToBePromise(getAllWorkspaceInputsResult);
@@ -1438,13 +1834,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/templates/values', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/templates/values', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getAllWorkspaceInputsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getAllWorkspaceInputsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getAllWorkspaceInputsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1452,7 +1863,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getAllWorkspaceInputsParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -1460,13 +1871,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getAllWorkspaceInputs(params);
+        schematicsService.getAllWorkspaceInputs(getAllWorkspaceInputsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getAllWorkspaceInputs({});
@@ -1475,32 +1886,33 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getAllWorkspaceInputsPromise = schematicsService.getAllWorkspaceInputs();
-        expectToBePromise(getAllWorkspaceInputsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getAllWorkspaceInputs();
+        } catch (e) {
+          err = e;
+        }
 
-        getAllWorkspaceInputsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceInputMetadata', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceInputMetadataTest() {
         // Construct the params object for operation getWorkspaceInputMetadata
         const wId = 'testString';
         const tId = 'testString';
-        const params = {
+        const getWorkspaceInputMetadataParams = {
           wId,
           tId,
         };
 
-        const getWorkspaceInputMetadataResult = schematicsService.getWorkspaceInputMetadata(params);
+        const getWorkspaceInputMetadataResult = schematicsService.getWorkspaceInputMetadata(getWorkspaceInputMetadataParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceInputMetadataResult);
@@ -1508,18 +1920,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          options,
-          '/v1/workspaces/{w_id}/template_data/{t_id}/values_metadata',
-          'GET'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/template_data/{t_id}/values_metadata', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.t_id).toEqual(tId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.t_id).toEqual(tId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceInputMetadataTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceInputMetadataTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceInputMetadataTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1528,7 +1951,7 @@ describe('SchematicsV1', () => {
         const tId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceInputMetadataParams = {
           wId,
           tId,
           headers: {
@@ -1537,13 +1960,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceInputMetadata(params);
+        schematicsService.getWorkspaceInputMetadata(getWorkspaceInputMetadataParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceInputMetadata({});
@@ -1552,30 +1975,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceInputMetadataPromise = schematicsService.getWorkspaceInputMetadata();
-        expectToBePromise(getWorkspaceInputMetadataPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceInputMetadata();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceInputMetadataPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceOutputs', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceOutputsTest() {
         // Construct the params object for operation getWorkspaceOutputs
         const wId = 'testString';
-        const params = {
+        const getWorkspaceOutputsParams = {
           wId,
         };
 
-        const getWorkspaceOutputsResult = schematicsService.getWorkspaceOutputs(params);
+        const getWorkspaceOutputsResult = schematicsService.getWorkspaceOutputs(getWorkspaceOutputsParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceOutputsResult);
@@ -1583,13 +2007,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/output_values', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/output_values', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceOutputsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceOutputsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceOutputsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1597,7 +2036,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceOutputsParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -1605,13 +2044,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceOutputs(params);
+        schematicsService.getWorkspaceOutputs(getWorkspaceOutputsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceOutputs({});
@@ -1620,30 +2059,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceOutputsPromise = schematicsService.getWorkspaceOutputs();
-        expectToBePromise(getWorkspaceOutputsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceOutputs();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceOutputsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceResources', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceResourcesTest() {
         // Construct the params object for operation getWorkspaceResources
         const wId = 'testString';
-        const params = {
+        const getWorkspaceResourcesParams = {
           wId,
         };
 
-        const getWorkspaceResourcesResult = schematicsService.getWorkspaceResources(params);
+        const getWorkspaceResourcesResult = schematicsService.getWorkspaceResources(getWorkspaceResourcesParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceResourcesResult);
@@ -1651,13 +2091,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/resources', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/resources', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceResourcesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceResourcesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceResourcesTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1665,7 +2120,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceResourcesParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -1673,13 +2128,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceResources(params);
+        schematicsService.getWorkspaceResources(getWorkspaceResourcesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceResources({});
@@ -1688,30 +2143,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceResourcesPromise = schematicsService.getWorkspaceResources();
-        expectToBePromise(getWorkspaceResourcesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceResources();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceResourcesPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceState', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceStateTest() {
         // Construct the params object for operation getWorkspaceState
         const wId = 'testString';
-        const params = {
+        const getWorkspaceStateParams = {
           wId,
         };
 
-        const getWorkspaceStateResult = schematicsService.getWorkspaceState(params);
+        const getWorkspaceStateResult = schematicsService.getWorkspaceState(getWorkspaceStateParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceStateResult);
@@ -1719,13 +2175,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/state_stores', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/state_stores', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceStateTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceStateTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceStateTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1733,7 +2204,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceStateParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -1741,13 +2212,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceState(params);
+        schematicsService.getWorkspaceState(getWorkspaceStateParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceState({});
@@ -1756,32 +2227,33 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceStatePromise = schematicsService.getWorkspaceState();
-        expectToBePromise(getWorkspaceStatePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceState();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceStatePromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceTemplateState', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceTemplateStateTest() {
         // Construct the params object for operation getWorkspaceTemplateState
         const wId = 'testString';
         const tId = 'testString';
-        const params = {
+        const getWorkspaceTemplateStateParams = {
           wId,
           tId,
         };
 
-        const getWorkspaceTemplateStateResult = schematicsService.getWorkspaceTemplateState(params);
+        const getWorkspaceTemplateStateResult = schematicsService.getWorkspaceTemplateState(getWorkspaceTemplateStateParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceTemplateStateResult);
@@ -1789,14 +2261,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/runtime_data/{t_id}/state_store', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/runtime_data/{t_id}/state_store', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.t_id).toEqual(tId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.t_id).toEqual(tId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceTemplateStateTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceTemplateStateTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceTemplateStateTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1805,7 +2292,7 @@ describe('SchematicsV1', () => {
         const tId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceTemplateStateParams = {
           wId,
           tId,
           headers: {
@@ -1814,13 +2301,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceTemplateState(params);
+        schematicsService.getWorkspaceTemplateState(getWorkspaceTemplateStateParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceTemplateState({});
@@ -1829,32 +2316,33 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceTemplateStatePromise = schematicsService.getWorkspaceTemplateState();
-        expectToBePromise(getWorkspaceTemplateStatePromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceTemplateState();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceTemplateStatePromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceActivityLogs', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceActivityLogsTest() {
         // Construct the params object for operation getWorkspaceActivityLogs
         const wId = 'testString';
         const activityId = 'testString';
-        const params = {
+        const getWorkspaceActivityLogsParams = {
           wId,
           activityId,
         };
 
-        const getWorkspaceActivityLogsResult = schematicsService.getWorkspaceActivityLogs(params);
+        const getWorkspaceActivityLogsResult = schematicsService.getWorkspaceActivityLogs(getWorkspaceActivityLogsParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceActivityLogsResult);
@@ -1862,14 +2350,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/actions/{activity_id}/logs', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/actions/{activity_id}/logs', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.activity_id).toEqual(activityId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.activity_id).toEqual(activityId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceActivityLogsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceActivityLogsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceActivityLogsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1878,7 +2381,7 @@ describe('SchematicsV1', () => {
         const activityId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceActivityLogsParams = {
           wId,
           activityId,
           headers: {
@@ -1887,13 +2390,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceActivityLogs(params);
+        schematicsService.getWorkspaceActivityLogs(getWorkspaceActivityLogsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceActivityLogs({});
@@ -1902,30 +2405,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceActivityLogsPromise = schematicsService.getWorkspaceActivityLogs();
-        expectToBePromise(getWorkspaceActivityLogsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceActivityLogs();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceActivityLogsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceLogUrls', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceLogUrlsTest() {
         // Construct the params object for operation getWorkspaceLogUrls
         const wId = 'testString';
-        const params = {
+        const getWorkspaceLogUrlsParams = {
           wId,
         };
 
-        const getWorkspaceLogUrlsResult = schematicsService.getWorkspaceLogUrls(params);
+        const getWorkspaceLogUrlsResult = schematicsService.getWorkspaceLogUrls(getWorkspaceLogUrlsParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceLogUrlsResult);
@@ -1933,13 +2437,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/log_stores', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/log_stores', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceLogUrlsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceLogUrlsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceLogUrlsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -1947,7 +2466,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceLogUrlsParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -1955,13 +2474,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceLogUrls(params);
+        schematicsService.getWorkspaceLogUrls(getWorkspaceLogUrlsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceLogUrls({});
@@ -1970,23 +2489,24 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceLogUrlsPromise = schematicsService.getWorkspaceLogUrls();
-        expectToBePromise(getWorkspaceLogUrlsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceLogUrls();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceLogUrlsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getTemplateLogs', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getTemplateLogsTest() {
         // Construct the params object for operation getTemplateLogs
         const wId = 'testString';
         const tId = 'testString';
@@ -1994,7 +2514,7 @@ describe('SchematicsV1', () => {
         const logTfPrefix = true;
         const logTfNullResource = true;
         const logTfAnsible = true;
-        const params = {
+        const getTemplateLogsParams = {
           wId,
           tId,
           logTfCmd,
@@ -2003,7 +2523,7 @@ describe('SchematicsV1', () => {
           logTfAnsible,
         };
 
-        const getTemplateLogsResult = schematicsService.getTemplateLogs(params);
+        const getTemplateLogsResult = schematicsService.getTemplateLogs(getTemplateLogsParams);
 
         // all methods should return a Promise
         expectToBePromise(getTemplateLogsResult);
@@ -2011,18 +2531,33 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/runtime_data/{t_id}/log_store', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/runtime_data/{t_id}/log_store', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.log_tf_cmd).toEqual(logTfCmd);
-        expect(options.qs.log_tf_prefix).toEqual(logTfPrefix);
-        expect(options.qs.log_tf_null_resource).toEqual(logTfNullResource);
-        expect(options.qs.log_tf_ansible).toEqual(logTfAnsible);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.t_id).toEqual(tId);
+        expect(mockRequestOptions.qs.log_tf_cmd).toEqual(logTfCmd);
+        expect(mockRequestOptions.qs.log_tf_prefix).toEqual(logTfPrefix);
+        expect(mockRequestOptions.qs.log_tf_null_resource).toEqual(logTfNullResource);
+        expect(mockRequestOptions.qs.log_tf_ansible).toEqual(logTfAnsible);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.t_id).toEqual(tId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getTemplateLogsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getTemplateLogsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getTemplateLogsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2031,7 +2566,7 @@ describe('SchematicsV1', () => {
         const tId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getTemplateLogsParams = {
           wId,
           tId,
           headers: {
@@ -2040,13 +2575,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getTemplateLogs(params);
+        schematicsService.getTemplateLogs(getTemplateLogsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getTemplateLogs({});
@@ -2055,23 +2590,24 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getTemplateLogsPromise = schematicsService.getTemplateLogs();
-        expectToBePromise(getTemplateLogsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getTemplateLogs();
+        } catch (e) {
+          err = e;
+        }
 
-        getTemplateLogsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getTemplateActivityLog', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getTemplateActivityLogTest() {
         // Construct the params object for operation getTemplateActivityLog
         const wId = 'testString';
         const tId = 'testString';
@@ -2080,7 +2616,7 @@ describe('SchematicsV1', () => {
         const logTfPrefix = true;
         const logTfNullResource = true;
         const logTfAnsible = true;
-        const params = {
+        const getTemplateActivityLogParams = {
           wId,
           tId,
           activityId,
@@ -2090,7 +2626,7 @@ describe('SchematicsV1', () => {
           logTfAnsible,
         };
 
-        const getTemplateActivityLogResult = schematicsService.getTemplateActivityLog(params);
+        const getTemplateActivityLogResult = schematicsService.getTemplateActivityLog(getTemplateActivityLogParams);
 
         // all methods should return a Promise
         expectToBePromise(getTemplateActivityLogResult);
@@ -2098,23 +2634,34 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(
-          options,
-          '/v1/workspaces/{w_id}/runtime_data/{t_id}/log_store/actions/{activity_id}',
-          'GET'
-        );
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/runtime_data/{t_id}/log_store/actions/{activity_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.log_tf_cmd).toEqual(logTfCmd);
-        expect(options.qs.log_tf_prefix).toEqual(logTfPrefix);
-        expect(options.qs.log_tf_null_resource).toEqual(logTfNullResource);
-        expect(options.qs.log_tf_ansible).toEqual(logTfAnsible);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.t_id).toEqual(tId);
-        expect(options.path.activity_id).toEqual(activityId);
+        expect(mockRequestOptions.qs.log_tf_cmd).toEqual(logTfCmd);
+        expect(mockRequestOptions.qs.log_tf_prefix).toEqual(logTfPrefix);
+        expect(mockRequestOptions.qs.log_tf_null_resource).toEqual(logTfNullResource);
+        expect(mockRequestOptions.qs.log_tf_ansible).toEqual(logTfAnsible);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.t_id).toEqual(tId);
+        expect(mockRequestOptions.path.activity_id).toEqual(activityId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getTemplateActivityLogTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getTemplateActivityLogTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getTemplateActivityLogTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2124,7 +2671,7 @@ describe('SchematicsV1', () => {
         const activityId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getTemplateActivityLogParams = {
           wId,
           tId,
           activityId,
@@ -2134,13 +2681,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getTemplateActivityLog(params);
+        schematicsService.getTemplateActivityLog(getTemplateActivityLogParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getTemplateActivityLog({});
@@ -2149,36 +2696,37 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getTemplateActivityLogPromise = schematicsService.getTemplateActivityLog();
-        expectToBePromise(getTemplateActivityLogPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getTemplateActivityLog();
+        } catch (e) {
+          err = e;
+        }
 
-        getTemplateActivityLogPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('listActions', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listActionsTest() {
         // Construct the params object for operation listActions
         const offset = 0;
         const limit = 1;
         const sort = 'testString';
         const profile = 'ids';
-        const params = {
+        const listActionsParams = {
           offset,
           limit,
           sort,
           profile,
         };
 
-        const listActionsResult = schematicsService.listActions(params);
+        const listActionsResult = schematicsService.listActions(listActionsParams);
 
         // all methods should return a Promise
         expectToBePromise(listActionsResult);
@@ -2186,30 +2734,45 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/actions', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/actions', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.offset).toEqual(offset);
-        expect(options.qs.limit).toEqual(limit);
-        expect(options.qs.sort).toEqual(sort);
-        expect(options.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listActionsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listActionsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listActionsTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listActionsParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listActions(params);
+        schematicsService.listActions(listActionsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -2220,6 +2783,7 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('createAction', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -2231,8 +2795,8 @@ describe('SchematicsV1', () => {
         set_at: '2019-01-01T12:00:00.000Z',
       };
 
-      // ExternalSourceGit
-      const externalSourceGitModel = {
+      // GitSource
+      const gitSourceModel = {
         computed_git_repo_url: 'testString',
         git_repo_url: 'testString',
         git_token: 'testString',
@@ -2241,28 +2805,64 @@ describe('SchematicsV1', () => {
         git_branch: 'testString',
       };
 
-      // ExternalSourceCatalog
-      const externalSourceCatalogModel = {
+      // CatalogSource
+      const catalogSourceModel = {
         catalog_name: 'testString',
+        catalog_id: 'testString',
         offering_name: 'testString',
         offering_version: 'testString',
         offering_kind: 'testString',
+        offering_target_kind: 'testString',
         offering_id: 'testString',
         offering_version_id: 'testString',
+        offering_version_flavour_name: 'testString',
         offering_repo_url: 'testString',
-      };
-
-      // ExternalSourceCosBucket
-      const externalSourceCosBucketModel = {
-        cos_bucket_url: 'testString',
+        offering_provisioner_working_directory: 'testString',
+        dry_run: true,
+        owning_account: 'testString',
+        item_icon_url: 'testString',
+        item_id: 'testString',
+        item_name: 'testString',
+        item_readme_url: 'testString',
+        item_url: 'testString',
+        launch_url: 'testString',
       };
 
       // ExternalSource
       const externalSourceModel = {
         source_type: 'local',
-        git: externalSourceGitModel,
-        catalog: externalSourceCatalogModel,
-        cos_bucket: externalSourceCosBucketModel,
+        git: gitSourceModel,
+        catalog: catalogSourceModel,
+      };
+
+      // CredentialVariableMetadata
+      const credentialVariableMetadataModel = {
+        type: 'string',
+        aliases: ['testString'],
+        description: 'testString',
+        cloud_data_type: 'testString',
+        default_value: 'testString',
+        link_status: 'normal',
+        immutable: true,
+        hidden: true,
+        required: true,
+        position: 38,
+        group_by: 'testString',
+        source: 'testString',
+      };
+
+      // CredentialVariableData
+      const credentialVariableDataModel = {
+        name: 'testString',
+        value: 'testString',
+        use_default: true,
+        metadata: credentialVariableMetadataModel,
+      };
+
+      // BastionResourceDefinition
+      const bastionResourceDefinitionModel = {
+        name: 'testString',
+        host: 'testString',
       };
 
       // VariableMetadata
@@ -2270,10 +2870,13 @@ describe('SchematicsV1', () => {
         type: 'boolean',
         aliases: ['testString'],
         description: 'testString',
+        cloud_data_type: 'testString',
         default_value: 'testString',
+        link_status: 'normal',
         secure: true,
         immutable: true,
         hidden: true,
+        required: true,
         options: ['testString'],
         min_value: 38,
         max_value: 38,
@@ -2289,36 +2892,18 @@ describe('SchematicsV1', () => {
       const variableDataModel = {
         name: 'testString',
         value: 'testString',
+        use_default: true,
         metadata: variableMetadataModel,
       };
 
-      // BastionResourceDefinition
-      const bastionResourceDefinitionModel = {
-        name: 'testString',
-        host: 'testString',
-      };
-
-      // ActionState
-      const actionStateModel = {
-        status_code: 'normal',
-        status_job_id: 'testString',
-        status_message: 'testString',
-      };
-
-      // SystemLock
-      const systemLockModel = {
-        sys_locked: true,
-        sys_locked_by: 'testString',
-        sys_locked_at: '2019-01-01T12:00:00.000Z',
-      };
-
-      test('should pass the right params to createRequest', () => {
+      function __createActionTest() {
         // Construct the params object for operation createAction
         const name = 'Stop Action';
-        const description =
-          'The description of your action. The description can be up to 2048 characters long in size. **Example** you can use the description to stop the targets.';
+        const description = 'The description of your action. The description can be up to 2048 characters long in size. **Example** you can use the description to stop the targets.';
         const location = 'us-south';
         const resourceGroup = 'testString';
+        const bastionConnectionType = 'ssh';
+        const inventoryConnectionType = 'ssh';
         const tags = ['testString'];
         const userState = userStateModel;
         const sourceReadmeUrl = 'testString';
@@ -2326,21 +2911,21 @@ describe('SchematicsV1', () => {
         const sourceType = 'local';
         const commandParameter = 'testString';
         const inventory = 'testString';
-        const credentials = [variableDataModel];
+        const credentials = [credentialVariableDataModel];
         const bastion = bastionResourceDefinitionModel;
-        const bastionCredential = variableDataModel;
+        const bastionCredential = credentialVariableDataModel;
         const targetsIni = 'testString';
         const inputs = [variableDataModel];
         const outputs = [variableDataModel];
         const settings = [variableDataModel];
-        const state = actionStateModel;
-        const sysLock = systemLockModel;
         const xGithubToken = 'testString';
-        const params = {
+        const createActionParams = {
           name,
           description,
           location,
           resourceGroup,
+          bastionConnectionType,
+          inventoryConnectionType,
           tags,
           userState,
           sourceReadmeUrl,
@@ -2355,12 +2940,10 @@ describe('SchematicsV1', () => {
           inputs,
           outputs,
           settings,
-          state,
-          sysLock,
           xGithubToken,
         };
 
-        const createActionResult = schematicsService.createAction(params);
+        const createActionResult = schematicsService.createAction(createActionParams);
 
         // all methods should return a Promise
         expectToBePromise(createActionResult);
@@ -2368,47 +2951,62 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/actions', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v2/actions', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'X-Github-token', xGithubToken);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.resource_group).toEqual(resourceGroup);
-        expect(options.body.tags).toEqual(tags);
-        expect(options.body.user_state).toEqual(userState);
-        expect(options.body.source_readme_url).toEqual(sourceReadmeUrl);
-        expect(options.body.source).toEqual(source);
-        expect(options.body.source_type).toEqual(sourceType);
-        expect(options.body.command_parameter).toEqual(commandParameter);
-        expect(options.body.inventory).toEqual(inventory);
-        expect(options.body.credentials).toEqual(credentials);
-        expect(options.body.bastion).toEqual(bastion);
-        expect(options.body.bastion_credential).toEqual(bastionCredential);
-        expect(options.body.targets_ini).toEqual(targetsIni);
-        expect(options.body.inputs).toEqual(inputs);
-        expect(options.body.outputs).toEqual(outputs);
-        expect(options.body.settings).toEqual(settings);
-        expect(options.body.state).toEqual(state);
-        expect(options.body.sys_lock).toEqual(sysLock);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.bastion_connection_type).toEqual(bastionConnectionType);
+        expect(mockRequestOptions.body.inventory_connection_type).toEqual(inventoryConnectionType);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.user_state).toEqual(userState);
+        expect(mockRequestOptions.body.source_readme_url).toEqual(sourceReadmeUrl);
+        expect(mockRequestOptions.body.source).toEqual(source);
+        expect(mockRequestOptions.body.source_type).toEqual(sourceType);
+        expect(mockRequestOptions.body.command_parameter).toEqual(commandParameter);
+        expect(mockRequestOptions.body.inventory).toEqual(inventory);
+        expect(mockRequestOptions.body.credentials).toEqual(credentials);
+        expect(mockRequestOptions.body.bastion).toEqual(bastion);
+        expect(mockRequestOptions.body.bastion_credential).toEqual(bastionCredential);
+        expect(mockRequestOptions.body.targets_ini).toEqual(targetsIni);
+        expect(mockRequestOptions.body.inputs).toEqual(inputs);
+        expect(mockRequestOptions.body.outputs).toEqual(outputs);
+        expect(mockRequestOptions.body.settings).toEqual(settings);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createActionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __createActionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __createActionTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createActionParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.createAction(params);
+        schematicsService.createAction(createActionParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -2419,18 +3017,19 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('getAction', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getActionTest() {
         // Construct the params object for operation getAction
         const actionId = 'testString';
         const profile = 'summary';
-        const params = {
+        const getActionParams = {
           actionId,
           profile,
         };
 
-        const getActionResult = schematicsService.getAction(params);
+        const getActionResult = schematicsService.getAction(getActionParams);
 
         // all methods should return a Promise
         expectToBePromise(getActionResult);
@@ -2438,14 +3037,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/actions/{action_id}', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/actions/{action_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.profile).toEqual(profile);
-        expect(options.path.action_id).toEqual(actionId);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.path.action_id).toEqual(actionId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getActionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getActionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getActionTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2453,7 +3067,7 @@ describe('SchematicsV1', () => {
         const actionId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getActionParams = {
           actionId,
           headers: {
             Accept: userAccept,
@@ -2461,13 +3075,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getAction(params);
+        schematicsService.getAction(getActionParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getAction({});
@@ -2476,34 +3090,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getActionPromise = schematicsService.getAction();
-        expectToBePromise(getActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getAction();
+        } catch (e) {
+          err = e;
+        }
 
-        getActionPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('deleteAction', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __deleteActionTest() {
         // Construct the params object for operation deleteAction
         const actionId = 'testString';
         const force = true;
         const propagate = true;
-        const params = {
+        const deleteActionParams = {
           actionId,
           force,
           propagate,
         };
 
-        const deleteActionResult = schematicsService.deleteAction(params);
+        const deleteActionResult = schematicsService.deleteAction(deleteActionParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteActionResult);
@@ -2511,15 +3126,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/actions/{action_id}', 'DELETE');
+        checkUrlAndMethod(mockRequestOptions, '/v2/actions/{action_id}', 'DELETE');
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'force', force);
         checkUserHeader(createRequestMock, 'propagate', propagate);
-        expect(options.path.action_id).toEqual(actionId);
+        expect(mockRequestOptions.path.action_id).toEqual(actionId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteActionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteActionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteActionTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2527,7 +3157,7 @@ describe('SchematicsV1', () => {
         const actionId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deleteActionParams = {
           actionId,
           headers: {
             Accept: userAccept,
@@ -2535,13 +3165,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.deleteAction(params);
+        schematicsService.deleteAction(deleteActionParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.deleteAction({});
@@ -2550,20 +3180,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const deleteActionPromise = schematicsService.deleteAction();
-        expectToBePromise(deleteActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.deleteAction();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteActionPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('updateAction', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -2575,8 +3206,8 @@ describe('SchematicsV1', () => {
         set_at: '2019-01-01T12:00:00.000Z',
       };
 
-      // ExternalSourceGit
-      const externalSourceGitModel = {
+      // GitSource
+      const gitSourceModel = {
         computed_git_repo_url: 'testString',
         git_repo_url: 'testString',
         git_token: 'testString',
@@ -2585,28 +3216,64 @@ describe('SchematicsV1', () => {
         git_branch: 'testString',
       };
 
-      // ExternalSourceCatalog
-      const externalSourceCatalogModel = {
+      // CatalogSource
+      const catalogSourceModel = {
         catalog_name: 'testString',
+        catalog_id: 'testString',
         offering_name: 'testString',
         offering_version: 'testString',
         offering_kind: 'testString',
+        offering_target_kind: 'testString',
         offering_id: 'testString',
         offering_version_id: 'testString',
+        offering_version_flavour_name: 'testString',
         offering_repo_url: 'testString',
-      };
-
-      // ExternalSourceCosBucket
-      const externalSourceCosBucketModel = {
-        cos_bucket_url: 'testString',
+        offering_provisioner_working_directory: 'testString',
+        dry_run: true,
+        owning_account: 'testString',
+        item_icon_url: 'testString',
+        item_id: 'testString',
+        item_name: 'testString',
+        item_readme_url: 'testString',
+        item_url: 'testString',
+        launch_url: 'testString',
       };
 
       // ExternalSource
       const externalSourceModel = {
         source_type: 'local',
-        git: externalSourceGitModel,
-        catalog: externalSourceCatalogModel,
-        cos_bucket: externalSourceCosBucketModel,
+        git: gitSourceModel,
+        catalog: catalogSourceModel,
+      };
+
+      // CredentialVariableMetadata
+      const credentialVariableMetadataModel = {
+        type: 'string',
+        aliases: ['testString'],
+        description: 'testString',
+        cloud_data_type: 'testString',
+        default_value: 'testString',
+        link_status: 'normal',
+        immutable: true,
+        hidden: true,
+        required: true,
+        position: 38,
+        group_by: 'testString',
+        source: 'testString',
+      };
+
+      // CredentialVariableData
+      const credentialVariableDataModel = {
+        name: 'testString',
+        value: 'testString',
+        use_default: true,
+        metadata: credentialVariableMetadataModel,
+      };
+
+      // BastionResourceDefinition
+      const bastionResourceDefinitionModel = {
+        name: 'testString',
+        host: 'testString',
       };
 
       // VariableMetadata
@@ -2614,10 +3281,13 @@ describe('SchematicsV1', () => {
         type: 'boolean',
         aliases: ['testString'],
         description: 'testString',
+        cloud_data_type: 'testString',
         default_value: 'testString',
+        link_status: 'normal',
         secure: true,
         immutable: true,
         hidden: true,
+        required: true,
         options: ['testString'],
         min_value: 38,
         max_value: 38,
@@ -2633,37 +3303,19 @@ describe('SchematicsV1', () => {
       const variableDataModel = {
         name: 'testString',
         value: 'testString',
+        use_default: true,
         metadata: variableMetadataModel,
       };
 
-      // BastionResourceDefinition
-      const bastionResourceDefinitionModel = {
-        name: 'testString',
-        host: 'testString',
-      };
-
-      // ActionState
-      const actionStateModel = {
-        status_code: 'normal',
-        status_job_id: 'testString',
-        status_message: 'testString',
-      };
-
-      // SystemLock
-      const systemLockModel = {
-        sys_locked: true,
-        sys_locked_by: 'testString',
-        sys_locked_at: '2019-01-01T12:00:00.000Z',
-      };
-
-      test('should pass the right params to createRequest', () => {
+      function __updateActionTest() {
         // Construct the params object for operation updateAction
         const actionId = 'testString';
         const name = 'Stop Action';
-        const description =
-          'The description of your action. The description can be up to 2048 characters long in size. **Example** you can use the description to stop the targets.';
+        const description = 'The description of your action. The description can be up to 2048 characters long in size. **Example** you can use the description to stop the targets.';
         const location = 'us-south';
         const resourceGroup = 'testString';
+        const bastionConnectionType = 'ssh';
+        const inventoryConnectionType = 'ssh';
         const tags = ['testString'];
         const userState = userStateModel;
         const sourceReadmeUrl = 'testString';
@@ -2671,22 +3323,22 @@ describe('SchematicsV1', () => {
         const sourceType = 'local';
         const commandParameter = 'testString';
         const inventory = 'testString';
-        const credentials = [variableDataModel];
+        const credentials = [credentialVariableDataModel];
         const bastion = bastionResourceDefinitionModel;
-        const bastionCredential = variableDataModel;
+        const bastionCredential = credentialVariableDataModel;
         const targetsIni = 'testString';
         const inputs = [variableDataModel];
         const outputs = [variableDataModel];
         const settings = [variableDataModel];
-        const state = actionStateModel;
-        const sysLock = systemLockModel;
         const xGithubToken = 'testString';
-        const params = {
+        const updateActionParams = {
           actionId,
           name,
           description,
           location,
           resourceGroup,
+          bastionConnectionType,
+          inventoryConnectionType,
           tags,
           userState,
           sourceReadmeUrl,
@@ -2701,12 +3353,10 @@ describe('SchematicsV1', () => {
           inputs,
           outputs,
           settings,
-          state,
-          sysLock,
           xGithubToken,
         };
 
-        const updateActionResult = schematicsService.updateAction(params);
+        const updateActionResult = schematicsService.updateAction(updateActionParams);
 
         // all methods should return a Promise
         expectToBePromise(updateActionResult);
@@ -2714,34 +3364,49 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/actions/{action_id}', 'PATCH');
+        checkUrlAndMethod(mockRequestOptions, '/v2/actions/{action_id}', 'PATCH');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'X-Github-token', xGithubToken);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.resource_group).toEqual(resourceGroup);
-        expect(options.body.tags).toEqual(tags);
-        expect(options.body.user_state).toEqual(userState);
-        expect(options.body.source_readme_url).toEqual(sourceReadmeUrl);
-        expect(options.body.source).toEqual(source);
-        expect(options.body.source_type).toEqual(sourceType);
-        expect(options.body.command_parameter).toEqual(commandParameter);
-        expect(options.body.inventory).toEqual(inventory);
-        expect(options.body.credentials).toEqual(credentials);
-        expect(options.body.bastion).toEqual(bastion);
-        expect(options.body.bastion_credential).toEqual(bastionCredential);
-        expect(options.body.targets_ini).toEqual(targetsIni);
-        expect(options.body.inputs).toEqual(inputs);
-        expect(options.body.outputs).toEqual(outputs);
-        expect(options.body.settings).toEqual(settings);
-        expect(options.body.state).toEqual(state);
-        expect(options.body.sys_lock).toEqual(sysLock);
-        expect(options.path.action_id).toEqual(actionId);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.bastion_connection_type).toEqual(bastionConnectionType);
+        expect(mockRequestOptions.body.inventory_connection_type).toEqual(inventoryConnectionType);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.user_state).toEqual(userState);
+        expect(mockRequestOptions.body.source_readme_url).toEqual(sourceReadmeUrl);
+        expect(mockRequestOptions.body.source).toEqual(source);
+        expect(mockRequestOptions.body.source_type).toEqual(sourceType);
+        expect(mockRequestOptions.body.command_parameter).toEqual(commandParameter);
+        expect(mockRequestOptions.body.inventory).toEqual(inventory);
+        expect(mockRequestOptions.body.credentials).toEqual(credentials);
+        expect(mockRequestOptions.body.bastion).toEqual(bastion);
+        expect(mockRequestOptions.body.bastion_credential).toEqual(bastionCredential);
+        expect(mockRequestOptions.body.targets_ini).toEqual(targetsIni);
+        expect(mockRequestOptions.body.inputs).toEqual(inputs);
+        expect(mockRequestOptions.body.outputs).toEqual(outputs);
+        expect(mockRequestOptions.body.settings).toEqual(settings);
+        expect(mockRequestOptions.path.action_id).toEqual(actionId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateActionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __updateActionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __updateActionTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2749,7 +3414,7 @@ describe('SchematicsV1', () => {
         const actionId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const updateActionParams = {
           actionId,
           headers: {
             Accept: userAccept,
@@ -2757,13 +3422,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.updateAction(params);
+        schematicsService.updateAction(updateActionParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.updateAction({});
@@ -2772,34 +3437,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const updateActionPromise = schematicsService.updateAction();
-        expectToBePromise(updateActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.updateAction();
+        } catch (e) {
+          err = e;
+        }
 
-        updateActionPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('uploadTemplateTarAction', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __uploadTemplateTarActionTest() {
         // Construct the params object for operation uploadTemplateTarAction
         const actionId = 'testString';
         const file = Buffer.from('This is a mock file.');
         const fileContentType = 'testString';
-        const params = {
+        const uploadTemplateTarActionParams = {
           actionId,
           file,
           fileContentType,
         };
 
-        const uploadTemplateTarActionResult = schematicsService.uploadTemplateTarAction(params);
+        const uploadTemplateTarActionResult = schematicsService.uploadTemplateTarAction(uploadTemplateTarActionParams);
 
         // all methods should return a Promise
         expectToBePromise(uploadTemplateTarActionResult);
@@ -2807,15 +3473,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/actions/{action_id}/template_repo_upload', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v2/actions/{action_id}/template_repo_upload', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'multipart/form-data';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.formData.file.data).toEqual(file);
-        expect(options.formData.file.contentType).toEqual(fileContentType);
-        expect(options.path.action_id).toEqual(actionId);
+        expect(mockRequestOptions.formData.file.data).toEqual(file);
+        expect(mockRequestOptions.formData.file.contentType).toEqual(fileContentType);
+        expect(mockRequestOptions.path.action_id).toEqual(actionId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __uploadTemplateTarActionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __uploadTemplateTarActionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __uploadTemplateTarActionTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2823,7 +3504,7 @@ describe('SchematicsV1', () => {
         const actionId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const uploadTemplateTarActionParams = {
           actionId,
           headers: {
             Accept: userAccept,
@@ -2831,13 +3512,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.uploadTemplateTarAction(params);
+        schematicsService.uploadTemplateTarAction(uploadTemplateTarActionParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.uploadTemplateTarAction({});
@@ -2846,34 +3527,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const uploadTemplateTarActionPromise = schematicsService.uploadTemplateTarAction();
-        expectToBePromise(uploadTemplateTarActionPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.uploadTemplateTarAction();
+        } catch (e) {
+          err = e;
+        }
 
-        uploadTemplateTarActionPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('listWorkspaceActivities', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listWorkspaceActivitiesTest() {
         // Construct the params object for operation listWorkspaceActivities
         const wId = 'testString';
         const offset = 0;
         const limit = 1;
-        const params = {
+        const listWorkspaceActivitiesParams = {
           wId,
           offset,
           limit,
         };
 
-        const listWorkspaceActivitiesResult = schematicsService.listWorkspaceActivities(params);
+        const listWorkspaceActivitiesResult = schematicsService.listWorkspaceActivities(listWorkspaceActivitiesParams);
 
         // all methods should return a Promise
         expectToBePromise(listWorkspaceActivitiesResult);
@@ -2881,15 +3563,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/actions', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/actions', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.offset).toEqual(offset);
-        expect(options.qs.limit).toEqual(limit);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listWorkspaceActivitiesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listWorkspaceActivitiesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listWorkspaceActivitiesTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2897,7 +3594,7 @@ describe('SchematicsV1', () => {
         const wId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listWorkspaceActivitiesParams = {
           wId,
           headers: {
             Accept: userAccept,
@@ -2905,13 +3602,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.listWorkspaceActivities(params);
+        schematicsService.listWorkspaceActivities(listWorkspaceActivitiesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.listWorkspaceActivities({});
@@ -2920,32 +3617,33 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const listWorkspaceActivitiesPromise = schematicsService.listWorkspaceActivities();
-        expectToBePromise(listWorkspaceActivitiesPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.listWorkspaceActivities();
+        } catch (e) {
+          err = e;
+        }
 
-        listWorkspaceActivitiesPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceActivity', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceActivityTest() {
         // Construct the params object for operation getWorkspaceActivity
         const wId = 'testString';
         const activityId = 'testString';
-        const params = {
+        const getWorkspaceActivityParams = {
           wId,
           activityId,
         };
 
-        const getWorkspaceActivityResult = schematicsService.getWorkspaceActivity(params);
+        const getWorkspaceActivityResult = schematicsService.getWorkspaceActivity(getWorkspaceActivityParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceActivityResult);
@@ -2953,14 +3651,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/actions/{activity_id}', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/actions/{activity_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.activity_id).toEqual(activityId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.activity_id).toEqual(activityId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceActivityTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceActivityTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceActivityTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2969,7 +3682,7 @@ describe('SchematicsV1', () => {
         const activityId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceActivityParams = {
           wId,
           activityId,
           headers: {
@@ -2978,13 +3691,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceActivity(params);
+        schematicsService.getWorkspaceActivity(getWorkspaceActivityParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceActivity({});
@@ -2993,32 +3706,33 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceActivityPromise = schematicsService.getWorkspaceActivity();
-        expectToBePromise(getWorkspaceActivityPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceActivity();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceActivityPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('deleteWorkspaceActivity', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __deleteWorkspaceActivityTest() {
         // Construct the params object for operation deleteWorkspaceActivity
         const wId = 'testString';
         const activityId = 'testString';
-        const params = {
+        const deleteWorkspaceActivityParams = {
           wId,
           activityId,
         };
 
-        const deleteWorkspaceActivityResult = schematicsService.deleteWorkspaceActivity(params);
+        const deleteWorkspaceActivityResult = schematicsService.deleteWorkspaceActivity(deleteWorkspaceActivityParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteWorkspaceActivityResult);
@@ -3026,14 +3740,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/actions/{activity_id}', 'DELETE');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/actions/{activity_id}', 'DELETE');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.w_id).toEqual(wId);
-        expect(options.path.activity_id).toEqual(activityId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.activity_id).toEqual(activityId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteWorkspaceActivityTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteWorkspaceActivityTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteWorkspaceActivityTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3042,7 +3771,7 @@ describe('SchematicsV1', () => {
         const activityId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deleteWorkspaceActivityParams = {
           wId,
           activityId,
           headers: {
@@ -3051,13 +3780,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.deleteWorkspaceActivity(params);
+        schematicsService.deleteWorkspaceActivity(deleteWorkspaceActivityParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.deleteWorkspaceActivity({});
@@ -3066,20 +3795,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const deleteWorkspaceActivityPromise = schematicsService.deleteWorkspaceActivity();
-        expectToBePromise(deleteWorkspaceActivityPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.deleteWorkspaceActivity();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteWorkspaceActivityPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('runWorkspaceCommands', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -3095,14 +3825,14 @@ describe('SchematicsV1', () => {
         command_status: 'testString',
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __runWorkspaceCommandsTest() {
         // Construct the params object for operation runWorkspaceCommands
         const wId = 'testString';
         const refreshToken = 'testString';
         const commands = [terraformCommandModel];
         const operationName = 'testString';
         const description = 'testString';
-        const params = {
+        const runWorkspaceCommandsParams = {
           wId,
           refreshToken,
           commands,
@@ -3110,7 +3840,7 @@ describe('SchematicsV1', () => {
           description,
         };
 
-        const runWorkspaceCommandsResult = schematicsService.runWorkspaceCommands(params);
+        const runWorkspaceCommandsResult = schematicsService.runWorkspaceCommands(runWorkspaceCommandsParams);
 
         // all methods should return a Promise
         expectToBePromise(runWorkspaceCommandsResult);
@@ -3118,17 +3848,32 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/commands', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/commands', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
-        expect(options.body.commands).toEqual(commands);
-        expect(options.body.operation_name).toEqual(operationName);
-        expect(options.body.description).toEqual(description);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.body.commands).toEqual(commands);
+        expect(mockRequestOptions.body.operation_name).toEqual(operationName);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __runWorkspaceCommandsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __runWorkspaceCommandsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __runWorkspaceCommandsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3137,7 +3882,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const runWorkspaceCommandsParams = {
           wId,
           refreshToken,
           headers: {
@@ -3146,13 +3891,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.runWorkspaceCommands(params);
+        schematicsService.runWorkspaceCommands(runWorkspaceCommandsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.runWorkspaceCommands({});
@@ -3161,20 +3906,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const runWorkspaceCommandsPromise = schematicsService.runWorkspaceCommands();
-        expectToBePromise(runWorkspaceCommandsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.runWorkspaceCommands();
+        } catch (e) {
+          err = e;
+        }
 
-        runWorkspaceCommandsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('applyWorkspaceCommand', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -3185,20 +3931,20 @@ describe('SchematicsV1', () => {
         tf_vars: ['testString'],
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __applyWorkspaceCommandTest() {
         // Construct the params object for operation applyWorkspaceCommand
         const wId = 'testString';
         const refreshToken = 'testString';
         const actionOptions = workspaceActivityOptionsTemplateModel;
         const delegatedToken = 'testString';
-        const params = {
+        const applyWorkspaceCommandParams = {
           wId,
           refreshToken,
           actionOptions,
           delegatedToken,
         };
 
-        const applyWorkspaceCommandResult = schematicsService.applyWorkspaceCommand(params);
+        const applyWorkspaceCommandResult = schematicsService.applyWorkspaceCommand(applyWorkspaceCommandParams);
 
         // all methods should return a Promise
         expectToBePromise(applyWorkspaceCommandResult);
@@ -3206,16 +3952,31 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/apply', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/apply', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
         checkUserHeader(createRequestMock, 'delegated_token', delegatedToken);
-        expect(options.body.action_options).toEqual(actionOptions);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.body.action_options).toEqual(actionOptions);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __applyWorkspaceCommandTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __applyWorkspaceCommandTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __applyWorkspaceCommandTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3224,7 +3985,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const applyWorkspaceCommandParams = {
           wId,
           refreshToken,
           headers: {
@@ -3233,13 +3994,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.applyWorkspaceCommand(params);
+        schematicsService.applyWorkspaceCommand(applyWorkspaceCommandParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.applyWorkspaceCommand({});
@@ -3248,20 +4009,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const applyWorkspaceCommandPromise = schematicsService.applyWorkspaceCommand();
-        expectToBePromise(applyWorkspaceCommandPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.applyWorkspaceCommand();
+        } catch (e) {
+          err = e;
+        }
 
-        applyWorkspaceCommandPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('destroyWorkspaceCommand', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -3272,20 +4034,20 @@ describe('SchematicsV1', () => {
         tf_vars: ['testString'],
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __destroyWorkspaceCommandTest() {
         // Construct the params object for operation destroyWorkspaceCommand
         const wId = 'testString';
         const refreshToken = 'testString';
         const actionOptions = workspaceActivityOptionsTemplateModel;
         const delegatedToken = 'testString';
-        const params = {
+        const destroyWorkspaceCommandParams = {
           wId,
           refreshToken,
           actionOptions,
           delegatedToken,
         };
 
-        const destroyWorkspaceCommandResult = schematicsService.destroyWorkspaceCommand(params);
+        const destroyWorkspaceCommandResult = schematicsService.destroyWorkspaceCommand(destroyWorkspaceCommandParams);
 
         // all methods should return a Promise
         expectToBePromise(destroyWorkspaceCommandResult);
@@ -3293,16 +4055,31 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/destroy', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/destroy', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
         checkUserHeader(createRequestMock, 'delegated_token', delegatedToken);
-        expect(options.body.action_options).toEqual(actionOptions);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.body.action_options).toEqual(actionOptions);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __destroyWorkspaceCommandTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __destroyWorkspaceCommandTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __destroyWorkspaceCommandTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3311,7 +4088,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const destroyWorkspaceCommandParams = {
           wId,
           refreshToken,
           headers: {
@@ -3320,13 +4097,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.destroyWorkspaceCommand(params);
+        schematicsService.destroyWorkspaceCommand(destroyWorkspaceCommandParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.destroyWorkspaceCommand({});
@@ -3335,34 +4112,45 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const destroyWorkspaceCommandPromise = schematicsService.destroyWorkspaceCommand();
-        expectToBePromise(destroyWorkspaceCommandPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.destroyWorkspaceCommand();
+        } catch (e) {
+          err = e;
+        }
 
-        destroyWorkspaceCommandPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('planWorkspaceCommand', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      // Request models needed by this operation.
+
+      // WorkspaceActivityOptionsTemplate
+      const workspaceActivityOptionsTemplateModel = {
+        target: ['testString'],
+        tf_vars: ['testString'],
+      };
+
+      function __planWorkspaceCommandTest() {
         // Construct the params object for operation planWorkspaceCommand
         const wId = 'testString';
         const refreshToken = 'testString';
+        const actionOptions = workspaceActivityOptionsTemplateModel;
         const delegatedToken = 'testString';
-        const params = {
+        const planWorkspaceCommandParams = {
           wId,
           refreshToken,
+          actionOptions,
           delegatedToken,
         };
 
-        const planWorkspaceCommandResult = schematicsService.planWorkspaceCommand(params);
+        const planWorkspaceCommandResult = schematicsService.planWorkspaceCommand(planWorkspaceCommandParams);
 
         // all methods should return a Promise
         expectToBePromise(planWorkspaceCommandResult);
@@ -3370,15 +4158,31 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/plan', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/plan', 'POST');
         const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
+        const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
         checkUserHeader(createRequestMock, 'delegated_token', delegatedToken);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.body.action_options).toEqual(actionOptions);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __planWorkspaceCommandTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __planWorkspaceCommandTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __planWorkspaceCommandTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3387,7 +4191,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const planWorkspaceCommandParams = {
           wId,
           refreshToken,
           headers: {
@@ -3396,13 +4200,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.planWorkspaceCommand(params);
+        schematicsService.planWorkspaceCommand(planWorkspaceCommandParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.planWorkspaceCommand({});
@@ -3411,34 +4215,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const planWorkspaceCommandPromise = schematicsService.planWorkspaceCommand();
-        expectToBePromise(planWorkspaceCommandPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.planWorkspaceCommand();
+        } catch (e) {
+          err = e;
+        }
 
-        planWorkspaceCommandPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('refreshWorkspaceCommand', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __refreshWorkspaceCommandTest() {
         // Construct the params object for operation refreshWorkspaceCommand
         const wId = 'testString';
         const refreshToken = 'testString';
         const delegatedToken = 'testString';
-        const params = {
+        const refreshWorkspaceCommandParams = {
           wId,
           refreshToken,
           delegatedToken,
         };
 
-        const refreshWorkspaceCommandResult = schematicsService.refreshWorkspaceCommand(params);
+        const refreshWorkspaceCommandResult = schematicsService.refreshWorkspaceCommand(refreshWorkspaceCommandParams);
 
         // all methods should return a Promise
         expectToBePromise(refreshWorkspaceCommandResult);
@@ -3446,15 +4251,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspaces/{w_id}/refresh', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspaces/{w_id}/refresh', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
         checkUserHeader(createRequestMock, 'delegated_token', delegatedToken);
-        expect(options.path.w_id).toEqual(wId);
+        expect(mockRequestOptions.path.w_id).toEqual(wId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __refreshWorkspaceCommandTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __refreshWorkspaceCommandTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __refreshWorkspaceCommandTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3463,7 +4283,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const refreshWorkspaceCommandParams = {
           wId,
           refreshToken,
           headers: {
@@ -3472,13 +4292,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.refreshWorkspaceCommand(params);
+        schematicsService.refreshWorkspaceCommand(refreshWorkspaceCommandParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.refreshWorkspaceCommand({});
@@ -3487,33 +4307,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const refreshWorkspaceCommandPromise = schematicsService.refreshWorkspaceCommand();
-        expectToBePromise(refreshWorkspaceCommandPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.refreshWorkspaceCommand();
+        } catch (e) {
+          err = e;
+        }
 
-        refreshWorkspaceCommandPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('listJobs', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listJobsTest() {
         // Construct the params object for operation listJobs
         const offset = 0;
         const limit = 1;
         const sort = 'testString';
         const profile = 'ids';
-        const resource = 'workspace';
+        const resource = 'workspaces';
         const resourceId = 'testString';
         const actionId = 'testString';
+        const workspaceId = 'testString';
         const list = 'all';
-        const params = {
+        const listJobsParams = {
           offset,
           limit,
           sort,
@@ -3521,10 +4343,11 @@ describe('SchematicsV1', () => {
           resource,
           resourceId,
           actionId,
+          workspaceId,
           list,
         };
 
-        const listJobsResult = schematicsService.listJobs(params);
+        const listJobsResult = schematicsService.listJobs(listJobsParams);
 
         // all methods should return a Promise
         expectToBePromise(listJobsResult);
@@ -3532,34 +4355,50 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/jobs', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/jobs', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.offset).toEqual(offset);
-        expect(options.qs.limit).toEqual(limit);
-        expect(options.qs.sort).toEqual(sort);
-        expect(options.qs.profile).toEqual(profile);
-        expect(options.qs.resource).toEqual(resource);
-        expect(options.qs.resource_id).toEqual(resourceId);
-        expect(options.qs.action_id).toEqual(actionId);
-        expect(options.qs.list).toEqual(list);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.qs.resource).toEqual(resource);
+        expect(mockRequestOptions.qs.resource_id).toEqual(resourceId);
+        expect(mockRequestOptions.qs.action_id).toEqual(actionId);
+        expect(mockRequestOptions.qs.workspace_id).toEqual(workspaceId);
+        expect(mockRequestOptions.qs.list).toEqual(list);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listJobsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listJobsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listJobsTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listJobsParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listJobs(params);
+        schematicsService.listJobs(listJobsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -3570,6 +4409,7 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('createJob', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -3579,10 +4419,13 @@ describe('SchematicsV1', () => {
         type: 'boolean',
         aliases: ['testString'],
         description: 'testString',
+        cloud_data_type: 'testString',
         default_value: 'testString',
+        link_status: 'normal',
         secure: true,
         immutable: true,
         hidden: true,
+        required: true,
         options: ['testString'],
         min_value: 38,
         max_value: 38,
@@ -3598,6 +4441,7 @@ describe('SchematicsV1', () => {
       const variableDataModel = {
         name: 'testString',
         value: 'testString',
+        use_default: true,
         metadata: variableMetadataModel,
       };
 
@@ -3671,10 +4515,20 @@ describe('SchematicsV1', () => {
 
       // JobStatus
       const jobStatusModel = {
+        position_in_queue: 72.5,
+        total_in_queue: 72.5,
         workspace_job_status: jobStatusWorkspaceModel,
         action_job_status: jobStatusActionModel,
         system_job_status: jobStatusSystemModel,
         flow_job_status: jobStatusFlowModel,
+      };
+
+      // CartOrderData
+      const cartOrderDataModel = {
+        name: 'testString',
+        value: 'testString',
+        type: 'testString',
+        usage_kind: ['servicetags'],
       };
 
       // JobDataTemplate
@@ -3728,8 +4582,8 @@ describe('SchematicsV1', () => {
         updated_at: '2019-01-01T12:00:00.000Z',
       };
 
-      // ExternalSourceGit
-      const externalSourceGitModel = {
+      // GitSource
+      const gitSourceModel = {
         computed_git_repo_url: 'testString',
         git_repo_url: 'testString',
         git_token: 'testString',
@@ -3738,28 +4592,34 @@ describe('SchematicsV1', () => {
         git_branch: 'testString',
       };
 
-      // ExternalSourceCatalog
-      const externalSourceCatalogModel = {
+      // CatalogSource
+      const catalogSourceModel = {
         catalog_name: 'testString',
+        catalog_id: 'testString',
         offering_name: 'testString',
         offering_version: 'testString',
         offering_kind: 'testString',
+        offering_target_kind: 'testString',
         offering_id: 'testString',
         offering_version_id: 'testString',
+        offering_version_flavour_name: 'testString',
         offering_repo_url: 'testString',
-      };
-
-      // ExternalSourceCosBucket
-      const externalSourceCosBucketModel = {
-        cos_bucket_url: 'testString',
+        offering_provisioner_working_directory: 'testString',
+        dry_run: true,
+        owning_account: 'testString',
+        item_icon_url: 'testString',
+        item_id: 'testString',
+        item_name: 'testString',
+        item_readme_url: 'testString',
+        item_url: 'testString',
+        launch_url: 'testString',
       };
 
       // ExternalSource
       const externalSourceModel = {
         source_type: 'local',
-        git: externalSourceGitModel,
-        catalog: externalSourceCatalogModel,
-        cos_bucket: externalSourceCosBucketModel,
+        git: gitSourceModel,
+        catalog: catalogSourceModel,
       };
 
       // JobDataWorkItemLastJob
@@ -3810,10 +4670,12 @@ describe('SchematicsV1', () => {
       };
 
       // JobLogSummaryRepoDownloadJob
-      const jobLogSummaryRepoDownloadJobModel = {};
+      const jobLogSummaryRepoDownloadJobModel = {
+      };
 
       // JobLogSummaryWorkspaceJob
-      const jobLogSummaryWorkspaceJobModel = {};
+      const jobLogSummaryWorkspaceJobModel = {
+      };
 
       // JobLogSummaryWorkitems
       const jobLogSummaryWorkitemsModel = {
@@ -3858,7 +4720,14 @@ describe('SchematicsV1', () => {
         system_job: jobLogSummarySystemJobModel,
       };
 
-      test('should pass the right params to createRequest', () => {
+      // AgentInfo
+      const agentInfoModel = {
+        id: 'testString',
+        name: 'testString',
+        assignment_policy_id: 'testString',
+      };
+
+      function __createJobTest() {
         // Construct the params object for operation createJob
         const refreshToken = 'testString';
         const commandObject = 'workspace';
@@ -3871,10 +4740,12 @@ describe('SchematicsV1', () => {
         const tags = ['testString'];
         const location = 'us-south';
         const status = jobStatusModel;
+        const cartOrderData = [cartOrderDataModel];
         const data = jobDataModel;
         const bastion = bastionResourceDefinitionModel;
         const logSummary = jobLogSummaryModel;
-        const params = {
+        const agent = agentInfoModel;
+        const createJobParams = {
           refreshToken,
           commandObject,
           commandObjectId,
@@ -3886,12 +4757,14 @@ describe('SchematicsV1', () => {
           tags,
           location,
           status,
+          cartOrderData,
           data,
           bastion,
           logSummary,
+          agent,
         };
 
-        const createJobResult = schematicsService.createJob(params);
+        const createJobResult = schematicsService.createJob(createJobParams);
 
         // all methods should return a Promise
         expectToBePromise(createJobResult);
@@ -3899,26 +4772,43 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/jobs', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v2/jobs', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
-        expect(options.body.command_object).toEqual(commandObject);
-        expect(options.body.command_object_id).toEqual(commandObjectId);
-        expect(options.body.command_name).toEqual(commandName);
-        expect(options.body.command_parameter).toEqual(commandParameter);
-        expect(options.body.command_options).toEqual(commandOptions);
-        expect(options.body.inputs).toEqual(inputs);
-        expect(options.body.settings).toEqual(settings);
-        expect(options.body.tags).toEqual(tags);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.status).toEqual(status);
-        expect(options.body.data).toEqual(data);
-        expect(options.body.bastion).toEqual(bastion);
-        expect(options.body.log_summary).toEqual(logSummary);
+        expect(mockRequestOptions.body.command_object).toEqual(commandObject);
+        expect(mockRequestOptions.body.command_object_id).toEqual(commandObjectId);
+        expect(mockRequestOptions.body.command_name).toEqual(commandName);
+        expect(mockRequestOptions.body.command_parameter).toEqual(commandParameter);
+        expect(mockRequestOptions.body.command_options).toEqual(commandOptions);
+        expect(mockRequestOptions.body.inputs).toEqual(inputs);
+        expect(mockRequestOptions.body.settings).toEqual(settings);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.status).toEqual(status);
+        expect(mockRequestOptions.body.cart_order_data).toEqual(cartOrderData);
+        expect(mockRequestOptions.body.data).toEqual(data);
+        expect(mockRequestOptions.body.bastion).toEqual(bastion);
+        expect(mockRequestOptions.body.log_summary).toEqual(logSummary);
+        expect(mockRequestOptions.body.agent).toEqual(agent);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createJobTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __createJobTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __createJobTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3926,7 +4816,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createJobParams = {
           refreshToken,
           headers: {
             Accept: userAccept,
@@ -3934,13 +4824,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.createJob(params);
+        schematicsService.createJob(createJobParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.createJob({});
@@ -3949,32 +4839,33 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const createJobPromise = schematicsService.createJob();
-        expectToBePromise(createJobPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.createJob();
+        } catch (e) {
+          err = e;
+        }
 
-        createJobPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getJob', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getJobTest() {
         // Construct the params object for operation getJob
         const jobId = 'testString';
         const profile = 'summary';
-        const params = {
+        const getJobParams = {
           jobId,
           profile,
         };
 
-        const getJobResult = schematicsService.getJob(params);
+        const getJobResult = schematicsService.getJob(getJobParams);
 
         // all methods should return a Promise
         expectToBePromise(getJobResult);
@@ -3982,14 +4873,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/jobs/{job_id}', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/jobs/{job_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.profile).toEqual(profile);
-        expect(options.path.job_id).toEqual(jobId);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.path.job_id).toEqual(jobId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getJobTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getJobTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getJobTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -3997,7 +4903,7 @@ describe('SchematicsV1', () => {
         const jobId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getJobParams = {
           jobId,
           headers: {
             Accept: userAccept,
@@ -4005,13 +4911,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getJob(params);
+        schematicsService.getJob(getJobParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getJob({});
@@ -4020,20 +4926,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getJobPromise = schematicsService.getJob();
-        expectToBePromise(getJobPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getJob();
+        } catch (e) {
+          err = e;
+        }
 
-        getJobPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('updateJob', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -4043,10 +4950,13 @@ describe('SchematicsV1', () => {
         type: 'boolean',
         aliases: ['testString'],
         description: 'testString',
+        cloud_data_type: 'testString',
         default_value: 'testString',
+        link_status: 'normal',
         secure: true,
         immutable: true,
         hidden: true,
+        required: true,
         options: ['testString'],
         min_value: 38,
         max_value: 38,
@@ -4062,6 +4972,7 @@ describe('SchematicsV1', () => {
       const variableDataModel = {
         name: 'testString',
         value: 'testString',
+        use_default: true,
         metadata: variableMetadataModel,
       };
 
@@ -4135,10 +5046,20 @@ describe('SchematicsV1', () => {
 
       // JobStatus
       const jobStatusModel = {
+        position_in_queue: 72.5,
+        total_in_queue: 72.5,
         workspace_job_status: jobStatusWorkspaceModel,
         action_job_status: jobStatusActionModel,
         system_job_status: jobStatusSystemModel,
         flow_job_status: jobStatusFlowModel,
+      };
+
+      // CartOrderData
+      const cartOrderDataModel = {
+        name: 'testString',
+        value: 'testString',
+        type: 'testString',
+        usage_kind: ['servicetags'],
       };
 
       // JobDataTemplate
@@ -4192,8 +5113,8 @@ describe('SchematicsV1', () => {
         updated_at: '2019-01-01T12:00:00.000Z',
       };
 
-      // ExternalSourceGit
-      const externalSourceGitModel = {
+      // GitSource
+      const gitSourceModel = {
         computed_git_repo_url: 'testString',
         git_repo_url: 'testString',
         git_token: 'testString',
@@ -4202,28 +5123,34 @@ describe('SchematicsV1', () => {
         git_branch: 'testString',
       };
 
-      // ExternalSourceCatalog
-      const externalSourceCatalogModel = {
+      // CatalogSource
+      const catalogSourceModel = {
         catalog_name: 'testString',
+        catalog_id: 'testString',
         offering_name: 'testString',
         offering_version: 'testString',
         offering_kind: 'testString',
+        offering_target_kind: 'testString',
         offering_id: 'testString',
         offering_version_id: 'testString',
+        offering_version_flavour_name: 'testString',
         offering_repo_url: 'testString',
-      };
-
-      // ExternalSourceCosBucket
-      const externalSourceCosBucketModel = {
-        cos_bucket_url: 'testString',
+        offering_provisioner_working_directory: 'testString',
+        dry_run: true,
+        owning_account: 'testString',
+        item_icon_url: 'testString',
+        item_id: 'testString',
+        item_name: 'testString',
+        item_readme_url: 'testString',
+        item_url: 'testString',
+        launch_url: 'testString',
       };
 
       // ExternalSource
       const externalSourceModel = {
         source_type: 'local',
-        git: externalSourceGitModel,
-        catalog: externalSourceCatalogModel,
-        cos_bucket: externalSourceCosBucketModel,
+        git: gitSourceModel,
+        catalog: catalogSourceModel,
       };
 
       // JobDataWorkItemLastJob
@@ -4274,10 +5201,12 @@ describe('SchematicsV1', () => {
       };
 
       // JobLogSummaryRepoDownloadJob
-      const jobLogSummaryRepoDownloadJobModel = {};
+      const jobLogSummaryRepoDownloadJobModel = {
+      };
 
       // JobLogSummaryWorkspaceJob
-      const jobLogSummaryWorkspaceJobModel = {};
+      const jobLogSummaryWorkspaceJobModel = {
+      };
 
       // JobLogSummaryWorkitems
       const jobLogSummaryWorkitemsModel = {
@@ -4322,7 +5251,14 @@ describe('SchematicsV1', () => {
         system_job: jobLogSummarySystemJobModel,
       };
 
-      test('should pass the right params to createRequest', () => {
+      // AgentInfo
+      const agentInfoModel = {
+        id: 'testString',
+        name: 'testString',
+        assignment_policy_id: 'testString',
+      };
+
+      function __updateJobTest() {
         // Construct the params object for operation updateJob
         const jobId = 'testString';
         const refreshToken = 'testString';
@@ -4336,10 +5272,12 @@ describe('SchematicsV1', () => {
         const tags = ['testString'];
         const location = 'us-south';
         const status = jobStatusModel;
+        const cartOrderData = [cartOrderDataModel];
         const data = jobDataModel;
         const bastion = bastionResourceDefinitionModel;
         const logSummary = jobLogSummaryModel;
-        const params = {
+        const agent = agentInfoModel;
+        const updateJobParams = {
           jobId,
           refreshToken,
           commandObject,
@@ -4352,12 +5290,14 @@ describe('SchematicsV1', () => {
           tags,
           location,
           status,
+          cartOrderData,
           data,
           bastion,
           logSummary,
+          agent,
         };
 
-        const updateJobResult = schematicsService.updateJob(params);
+        const updateJobResult = schematicsService.updateJob(updateJobParams);
 
         // all methods should return a Promise
         expectToBePromise(updateJobResult);
@@ -4365,27 +5305,44 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/jobs/{job_id}', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v2/jobs/{job_id}', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
-        expect(options.body.command_object).toEqual(commandObject);
-        expect(options.body.command_object_id).toEqual(commandObjectId);
-        expect(options.body.command_name).toEqual(commandName);
-        expect(options.body.command_parameter).toEqual(commandParameter);
-        expect(options.body.command_options).toEqual(commandOptions);
-        expect(options.body.inputs).toEqual(inputs);
-        expect(options.body.settings).toEqual(settings);
-        expect(options.body.tags).toEqual(tags);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.status).toEqual(status);
-        expect(options.body.data).toEqual(data);
-        expect(options.body.bastion).toEqual(bastion);
-        expect(options.body.log_summary).toEqual(logSummary);
-        expect(options.path.job_id).toEqual(jobId);
+        expect(mockRequestOptions.body.command_object).toEqual(commandObject);
+        expect(mockRequestOptions.body.command_object_id).toEqual(commandObjectId);
+        expect(mockRequestOptions.body.command_name).toEqual(commandName);
+        expect(mockRequestOptions.body.command_parameter).toEqual(commandParameter);
+        expect(mockRequestOptions.body.command_options).toEqual(commandOptions);
+        expect(mockRequestOptions.body.inputs).toEqual(inputs);
+        expect(mockRequestOptions.body.settings).toEqual(settings);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.status).toEqual(status);
+        expect(mockRequestOptions.body.cart_order_data).toEqual(cartOrderData);
+        expect(mockRequestOptions.body.data).toEqual(data);
+        expect(mockRequestOptions.body.bastion).toEqual(bastion);
+        expect(mockRequestOptions.body.log_summary).toEqual(logSummary);
+        expect(mockRequestOptions.body.agent).toEqual(agent);
+        expect(mockRequestOptions.path.job_id).toEqual(jobId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateJobTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __updateJobTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __updateJobTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -4394,7 +5351,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const updateJobParams = {
           jobId,
           refreshToken,
           headers: {
@@ -4403,13 +5360,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.updateJob(params);
+        schematicsService.updateJob(updateJobParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.updateJob({});
@@ -4418,36 +5375,37 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const updateJobPromise = schematicsService.updateJob();
-        expectToBePromise(updateJobPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.updateJob();
+        } catch (e) {
+          err = e;
+        }
 
-        updateJobPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('deleteJob', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __deleteJobTest() {
         // Construct the params object for operation deleteJob
         const jobId = 'testString';
         const refreshToken = 'testString';
         const force = true;
         const propagate = true;
-        const params = {
+        const deleteJobParams = {
           jobId,
           refreshToken,
           force,
           propagate,
         };
 
-        const deleteJobResult = schematicsService.deleteJob(params);
+        const deleteJobResult = schematicsService.deleteJob(deleteJobParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteJobResult);
@@ -4455,16 +5413,31 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/jobs/{job_id}', 'DELETE');
+        checkUrlAndMethod(mockRequestOptions, '/v2/jobs/{job_id}', 'DELETE');
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
         checkUserHeader(createRequestMock, 'force', force);
         checkUserHeader(createRequestMock, 'propagate', propagate);
-        expect(options.path.job_id).toEqual(jobId);
+        expect(mockRequestOptions.path.job_id).toEqual(jobId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteJobTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteJobTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteJobTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -4473,7 +5446,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deleteJobParams = {
           jobId,
           refreshToken,
           headers: {
@@ -4482,13 +5455,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.deleteJob(params);
+        schematicsService.deleteJob(deleteJobParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.deleteJob({});
@@ -4497,30 +5470,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const deleteJobPromise = schematicsService.deleteJob();
-        expectToBePromise(deleteJobPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.deleteJob();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteJobPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('listJobLogs', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listJobLogsTest() {
         // Construct the params object for operation listJobLogs
         const jobId = 'testString';
-        const params = {
+        const listJobLogsParams = {
           jobId,
         };
 
-        const listJobLogsResult = schematicsService.listJobLogs(params);
+        const listJobLogsResult = schematicsService.listJobLogs(listJobLogsParams);
 
         // all methods should return a Promise
         expectToBePromise(listJobLogsResult);
@@ -4528,13 +5502,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/jobs/{job_id}/logs', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/jobs/{job_id}/logs', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.job_id).toEqual(jobId);
+        expect(mockRequestOptions.path.job_id).toEqual(jobId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listJobLogsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listJobLogsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listJobLogsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -4542,7 +5531,7 @@ describe('SchematicsV1', () => {
         const jobId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listJobLogsParams = {
           jobId,
           headers: {
             Accept: userAccept,
@@ -4550,13 +5539,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.listJobLogs(params);
+        schematicsService.listJobLogs(listJobLogsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.listJobLogs({});
@@ -4565,43 +5554,126 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const listJobLogsPromise = schematicsService.listJobLogs();
-        expectToBePromise(listJobLogsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.listJobLogs();
+        } catch (e) {
+          err = e;
+        }
 
-        listJobLogsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
-  describe('createWorkspaceDeletionJob', () => {
+
+  describe('getJobFiles', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
-        // Construct the params object for operation createWorkspaceDeletionJob
-        const refreshToken = 'testString';
-        const newDeleteWorkspaces = true;
-        const newDestroyResources = true;
-        const newJob = 'testString';
-        const newVersion = 'testString';
-        const newWorkspaces = ['testString'];
-        const destroyResources = 'testString';
-        const params = {
-          refreshToken,
-          newDeleteWorkspaces,
-          newDestroyResources,
-          newJob,
-          newVersion,
-          newWorkspaces,
-          destroyResources,
+      function __getJobFilesTest() {
+        // Construct the params object for operation getJobFiles
+        const jobId = 'testString';
+        const fileType = 'template_repo';
+        const getJobFilesParams = {
+          jobId,
+          fileType,
         };
 
-        const createWorkspaceDeletionJobResult =
-          schematicsService.createWorkspaceDeletionJob(params);
+        const getJobFilesResult = schematicsService.getJobFiles(getJobFilesParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getJobFilesResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/jobs/{job_id}/files', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.file_type).toEqual(fileType);
+        expect(mockRequestOptions.path.job_id).toEqual(jobId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getJobFilesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getJobFilesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getJobFilesTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const jobId = 'testString';
+        const fileType = 'template_repo';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getJobFilesParams = {
+          jobId,
+          fileType,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.getJobFiles(getJobFilesParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.getJobFiles({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getJobFiles();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('createWorkspaceDeletionJob', () => {
+    describe('positive tests', () => {
+      function __createWorkspaceDeletionJobTest() {
+        // Construct the params object for operation createWorkspaceDeletionJob
+        const refreshToken = 'testString';
+        const job = 'testString';
+        const version = 'testString';
+        const workspaces = ['testString'];
+        const createWorkspaceDeletionJobParams = {
+          refreshToken,
+          job,
+          version,
+          workspaces,
+        };
+
+        const createWorkspaceDeletionJobResult = schematicsService.createWorkspaceDeletionJob(createWorkspaceDeletionJobParams);
 
         // all methods should return a Promise
         expectToBePromise(createWorkspaceDeletionJobResult);
@@ -4609,19 +5681,31 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspace_jobs', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspace_jobs', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'refresh_token', refreshToken);
-        expect(options.body.delete_workspaces).toEqual(newDeleteWorkspaces);
-        expect(options.body.destroy_resources).toEqual(newDestroyResources);
-        expect(options.body.job).toEqual(newJob);
-        expect(options.body.version).toEqual(newVersion);
-        expect(options.body.workspaces).toEqual(newWorkspaces);
-        expect(options.qs.destroy_resources).toEqual(destroyResources);
+        expect(mockRequestOptions.body.job).toEqual(job);
+        expect(mockRequestOptions.body.version).toEqual(version);
+        expect(mockRequestOptions.body.workspaces).toEqual(workspaces);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createWorkspaceDeletionJobTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __createWorkspaceDeletionJobTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __createWorkspaceDeletionJobTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -4629,7 +5713,7 @@ describe('SchematicsV1', () => {
         const refreshToken = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createWorkspaceDeletionJobParams = {
           refreshToken,
           headers: {
             Accept: userAccept,
@@ -4637,13 +5721,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.createWorkspaceDeletionJob(params);
+        schematicsService.createWorkspaceDeletionJob(createWorkspaceDeletionJobParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.createWorkspaceDeletionJob({});
@@ -4652,31 +5736,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const createWorkspaceDeletionJobPromise = schematicsService.createWorkspaceDeletionJob();
-        expectToBePromise(createWorkspaceDeletionJobPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.createWorkspaceDeletionJob();
+        } catch (e) {
+          err = e;
+        }
 
-        createWorkspaceDeletionJobPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('getWorkspaceDeletionJobStatus', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getWorkspaceDeletionJobStatusTest() {
         // Construct the params object for operation getWorkspaceDeletionJobStatus
         const wjId = 'testString';
-        const params = {
+        const getWorkspaceDeletionJobStatusParams = {
           wjId,
         };
 
-        const getWorkspaceDeletionJobStatusResult =
-          schematicsService.getWorkspaceDeletionJobStatus(params);
+        const getWorkspaceDeletionJobStatusResult = schematicsService.getWorkspaceDeletionJobStatus(getWorkspaceDeletionJobStatusParams);
 
         // all methods should return a Promise
         expectToBePromise(getWorkspaceDeletionJobStatusResult);
@@ -4684,13 +5768,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v1/workspace_jobs/{wj_id}/status', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v1/workspace_jobs/{wj_id}/status', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.wj_id).toEqual(wjId);
+        expect(mockRequestOptions.path.wj_id).toEqual(wjId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getWorkspaceDeletionJobStatusTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getWorkspaceDeletionJobStatusTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getWorkspaceDeletionJobStatusTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -4698,7 +5797,7 @@ describe('SchematicsV1', () => {
         const wjId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getWorkspaceDeletionJobStatusParams = {
           wjId,
           headers: {
             Accept: userAccept,
@@ -4706,13 +5805,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getWorkspaceDeletionJobStatus(params);
+        schematicsService.getWorkspaceDeletionJobStatus(getWorkspaceDeletionJobStatusParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getWorkspaceDeletionJobStatus({});
@@ -4721,37 +5820,797 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getWorkspaceDeletionJobStatusPromise =
-          schematicsService.getWorkspaceDeletionJobStatus();
-        expectToBePromise(getWorkspaceDeletionJobStatusPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getWorkspaceDeletionJobStatus();
+        } catch (e) {
+          err = e;
+        }
 
-        getWorkspaceDeletionJobStatusPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
+  describe('listBlueprint', () => {
+    describe('positive tests', () => {
+      function __listBlueprintTest() {
+        // Construct the params object for operation listBlueprint
+        const offset = 0;
+        const limit = 1;
+        const listBlueprintParams = {
+          offset,
+          limit,
+        };
+
+        const listBlueprintResult = schematicsService.listBlueprint(listBlueprintParams);
+
+        // all methods should return a Promise
+        expectToBePromise(listBlueprintResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/blueprints', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listBlueprintTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listBlueprintTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listBlueprintTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listBlueprintParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.listBlueprint(listBlueprintParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        schematicsService.listBlueprint({});
+        checkForSuccessfulExecution(createRequestMock);
+      });
+    });
+  });
+
+  describe('createBlueprint', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // GitSource
+      const gitSourceModel = {
+        computed_git_repo_url: 'testString',
+        git_repo_url: 'testString',
+        git_token: 'testString',
+        git_repo_folder: 'testString',
+        git_release: 'testString',
+        git_branch: 'testString',
+      };
+
+      // CatalogSource
+      const catalogSourceModel = {
+        catalog_name: 'testString',
+        catalog_id: 'testString',
+        offering_name: 'testString',
+        offering_version: 'testString',
+        offering_kind: 'testString',
+        offering_target_kind: 'testString',
+        offering_id: 'testString',
+        offering_version_id: 'testString',
+        offering_version_flavour_name: 'testString',
+        offering_repo_url: 'testString',
+        offering_provisioner_working_directory: 'testString',
+        dry_run: true,
+        owning_account: 'testString',
+        item_icon_url: 'testString',
+        item_id: 'testString',
+        item_name: 'testString',
+        item_readme_url: 'testString',
+        item_url: 'testString',
+        launch_url: 'testString',
+      };
+
+      // ExternalSource
+      const externalSourceModel = {
+        source_type: 'local',
+        git: gitSourceModel,
+        catalog: catalogSourceModel,
+      };
+
+      // VariableMetadata
+      const variableMetadataModel = {
+        type: 'boolean',
+        aliases: ['testString'],
+        description: 'testString',
+        cloud_data_type: 'testString',
+        default_value: 'testString',
+        link_status: 'normal',
+        secure: true,
+        immutable: true,
+        hidden: true,
+        required: true,
+        options: ['testString'],
+        min_value: 38,
+        max_value: 38,
+        min_length: 38,
+        max_length: 38,
+        matches: 'testString',
+        position: 38,
+        group_by: 'testString',
+        source: 'testString',
+      };
+
+      // VariableData
+      const variableDataModel = {
+        name: 'testString',
+        value: 'testString',
+        use_default: true,
+        metadata: variableMetadataModel,
+      };
+
+      // BlueprintConfigItem
+      const blueprintConfigItemModel = {
+        name: 'testString',
+        description: 'testString',
+        source: externalSourceModel,
+        inputs: [variableDataModel],
+      };
+
+      // BlueprintFlow
+      const blueprintFlowModel = {
+      };
+
+      // UserState
+      const userStateModel = {
+        state: 'draft',
+        set_by: 'testString',
+        set_at: '2019-01-01T12:00:00.000Z',
+      };
+
+      function __createBlueprintTest() {
+        // Construct the params object for operation createBlueprint
+        const name = 'Toronto Dev Environtment';
+        const schemaVersion = '1.0';
+        const source = externalSourceModel;
+        const config = [blueprintConfigItemModel];
+        const description = 'Deploys dev environtment instance in Toronto Region';
+        const resourceGroup = 'Default';
+        const tags = ['blueprint:Tor-Dev'];
+        const location = 'us-south';
+        const inputs = [variableDataModel];
+        const settings = [variableDataModel];
+        const flow = blueprintFlowModel;
+        const userState = userStateModel;
+        const createBlueprintParams = {
+          name,
+          schemaVersion,
+          source,
+          config,
+          description,
+          resourceGroup,
+          tags,
+          location,
+          inputs,
+          settings,
+          flow,
+          userState,
+        };
+
+        const createBlueprintResult = schematicsService.createBlueprint(createBlueprintParams);
+
+        // all methods should return a Promise
+        expectToBePromise(createBlueprintResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/blueprints', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.schema_version).toEqual(schemaVersion);
+        expect(mockRequestOptions.body.source).toEqual(source);
+        expect(mockRequestOptions.body.config).toEqual(config);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.inputs).toEqual(inputs);
+        expect(mockRequestOptions.body.settings).toEqual(settings);
+        expect(mockRequestOptions.body.flow).toEqual(flow);
+        expect(mockRequestOptions.body.user_state).toEqual(userState);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createBlueprintTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __createBlueprintTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __createBlueprintTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const name = 'Toronto Dev Environtment';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createBlueprintParams = {
+          name,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.createBlueprint(createBlueprintParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.createBlueprint({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.createBlueprint();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getBlueprint', () => {
+    describe('positive tests', () => {
+      function __getBlueprintTest() {
+        // Construct the params object for operation getBlueprint
+        const blueprintId = 'testString';
+        const profile = 'ids';
+        const getBlueprintParams = {
+          blueprintId,
+          profile,
+        };
+
+        const getBlueprintResult = schematicsService.getBlueprint(getBlueprintParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getBlueprintResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/blueprints/{blueprint_id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.path.blueprint_id).toEqual(blueprintId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getBlueprintTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getBlueprintTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getBlueprintTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const blueprintId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getBlueprintParams = {
+          blueprintId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.getBlueprint(getBlueprintParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.getBlueprint({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getBlueprint();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('replaceBlueprint', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // GitSource
+      const gitSourceModel = {
+        computed_git_repo_url: 'testString',
+        git_repo_url: 'testString',
+        git_token: 'testString',
+        git_repo_folder: 'testString',
+        git_release: 'testString',
+        git_branch: 'testString',
+      };
+
+      // CatalogSource
+      const catalogSourceModel = {
+        catalog_name: 'testString',
+        catalog_id: 'testString',
+        offering_name: 'testString',
+        offering_version: 'testString',
+        offering_kind: 'testString',
+        offering_target_kind: 'testString',
+        offering_id: 'testString',
+        offering_version_id: 'testString',
+        offering_version_flavour_name: 'testString',
+        offering_repo_url: 'testString',
+        offering_provisioner_working_directory: 'testString',
+        dry_run: true,
+        owning_account: 'testString',
+        item_icon_url: 'testString',
+        item_id: 'testString',
+        item_name: 'testString',
+        item_readme_url: 'testString',
+        item_url: 'testString',
+        launch_url: 'testString',
+      };
+
+      // ExternalSource
+      const externalSourceModel = {
+        source_type: 'local',
+        git: gitSourceModel,
+        catalog: catalogSourceModel,
+      };
+
+      // VariableMetadata
+      const variableMetadataModel = {
+        type: 'boolean',
+        aliases: ['testString'],
+        description: 'testString',
+        cloud_data_type: 'testString',
+        default_value: 'testString',
+        link_status: 'normal',
+        secure: true,
+        immutable: true,
+        hidden: true,
+        required: true,
+        options: ['testString'],
+        min_value: 38,
+        max_value: 38,
+        min_length: 38,
+        max_length: 38,
+        matches: 'testString',
+        position: 38,
+        group_by: 'testString',
+        source: 'testString',
+      };
+
+      // VariableData
+      const variableDataModel = {
+        name: 'testString',
+        value: 'testString',
+        use_default: true,
+        metadata: variableMetadataModel,
+      };
+
+      // BlueprintConfigItem
+      const blueprintConfigItemModel = {
+        name: 'testString',
+        description: 'testString',
+        source: externalSourceModel,
+        inputs: [variableDataModel],
+      };
+
+      // BlueprintFlow
+      const blueprintFlowModel = {
+      };
+
+      // UserState
+      const userStateModel = {
+        state: 'draft',
+        set_by: 'testString',
+        set_at: '2019-01-01T12:00:00.000Z',
+      };
+
+      function __replaceBlueprintTest() {
+        // Construct the params object for operation replaceBlueprint
+        const blueprintId = 'testString';
+        const name = 'Toronto Dev Environtment';
+        const schemaVersion = '1.0';
+        const source = externalSourceModel;
+        const config = [blueprintConfigItemModel];
+        const description = 'Deploys dev environtment instance in Toronto Region';
+        const resourceGroup = 'Default';
+        const tags = ['blueprint:Tor-Dev'];
+        const location = 'us-south';
+        const inputs = [variableDataModel];
+        const settings = [variableDataModel];
+        const flow = blueprintFlowModel;
+        const userState = userStateModel;
+        const profile = 'ids';
+        const replaceBlueprintParams = {
+          blueprintId,
+          name,
+          schemaVersion,
+          source,
+          config,
+          description,
+          resourceGroup,
+          tags,
+          location,
+          inputs,
+          settings,
+          flow,
+          userState,
+          profile,
+        };
+
+        const replaceBlueprintResult = schematicsService.replaceBlueprint(replaceBlueprintParams);
+
+        // all methods should return a Promise
+        expectToBePromise(replaceBlueprintResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/blueprints/{blueprint_id}', 'PUT');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.schema_version).toEqual(schemaVersion);
+        expect(mockRequestOptions.body.source).toEqual(source);
+        expect(mockRequestOptions.body.config).toEqual(config);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.inputs).toEqual(inputs);
+        expect(mockRequestOptions.body.settings).toEqual(settings);
+        expect(mockRequestOptions.body.flow).toEqual(flow);
+        expect(mockRequestOptions.body.user_state).toEqual(userState);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.path.blueprint_id).toEqual(blueprintId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __replaceBlueprintTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __replaceBlueprintTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __replaceBlueprintTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const blueprintId = 'testString';
+        const name = 'Toronto Dev Environtment';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const replaceBlueprintParams = {
+          blueprintId,
+          name,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.replaceBlueprint(replaceBlueprintParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.replaceBlueprint({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.replaceBlueprint();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteBlueprint', () => {
+    describe('positive tests', () => {
+      function __deleteBlueprintTest() {
+        // Construct the params object for operation deleteBlueprint
+        const blueprintId = 'testString';
+        const profile = 'ids';
+        const destroy = 0;
+        const deleteBlueprintParams = {
+          blueprintId,
+          profile,
+          destroy,
+        };
+
+        const deleteBlueprintResult = schematicsService.deleteBlueprint(deleteBlueprintParams);
+
+        // all methods should return a Promise
+        expectToBePromise(deleteBlueprintResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/blueprints/{blueprint_id}', 'DELETE');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.qs.destroy).toEqual(destroy);
+        expect(mockRequestOptions.path.blueprint_id).toEqual(blueprintId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteBlueprintTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteBlueprintTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteBlueprintTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const blueprintId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteBlueprintParams = {
+          blueprintId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.deleteBlueprint(deleteBlueprintParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.deleteBlueprint({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.deleteBlueprint();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('uploadTemplateTarBlueprint', () => {
+    describe('positive tests', () => {
+      function __uploadTemplateTarBlueprintTest() {
+        // Construct the params object for operation uploadTemplateTarBlueprint
+        const blueprintId = 'testString';
+        const file = Buffer.from('This is a mock file.');
+        const fileContentType = 'testString';
+        const uploadTemplateTarBlueprintParams = {
+          blueprintId,
+          file,
+          fileContentType,
+        };
+
+        const uploadTemplateTarBlueprintResult = schematicsService.uploadTemplateTarBlueprint(uploadTemplateTarBlueprintParams);
+
+        // all methods should return a Promise
+        expectToBePromise(uploadTemplateTarBlueprintResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/blueprints/{blueprint_id}/template_repo_upload', 'PUT');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'multipart/form-data';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.formData.file.data).toEqual(file);
+        expect(mockRequestOptions.formData.file.contentType).toEqual(fileContentType);
+        expect(mockRequestOptions.path.blueprint_id).toEqual(blueprintId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __uploadTemplateTarBlueprintTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __uploadTemplateTarBlueprintTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __uploadTemplateTarBlueprintTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const blueprintId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const uploadTemplateTarBlueprintParams = {
+          blueprintId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.uploadTemplateTarBlueprint(uploadTemplateTarBlueprintParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.uploadTemplateTarBlueprint({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.uploadTemplateTarBlueprint();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
   describe('listInventories', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listInventoriesTest() {
         // Construct the params object for operation listInventories
         const offset = 0;
         const limit = 1;
         const sort = 'testString';
         const profile = 'ids';
-        const params = {
+        const listInventoriesParams = {
           offset,
           limit,
           sort,
           profile,
         };
 
-        const listInventoriesResult = schematicsService.listInventories(params);
+        const listInventoriesResult = schematicsService.listInventories(listInventoriesParams);
 
         // all methods should return a Promise
         expectToBePromise(listInventoriesResult);
@@ -4759,30 +6618,45 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/inventories', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/inventories', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.offset).toEqual(offset);
-        expect(options.qs.limit).toEqual(limit);
-        expect(options.qs.sort).toEqual(sort);
-        expect(options.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listInventoriesTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listInventoriesTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listInventoriesTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listInventoriesParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listInventories(params);
+        schematicsService.listInventories(listInventoriesParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -4793,9 +6667,10 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('createInventory', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __createInventoryTest() {
         // Construct the params object for operation createInventory
         const name = 'testString';
         const description = 'testString';
@@ -4803,7 +6678,7 @@ describe('SchematicsV1', () => {
         const resourceGroup = 'testString';
         const inventoriesIni = 'testString';
         const resourceQueries = ['testString'];
-        const params = {
+        const createInventoryParams = {
           name,
           description,
           location,
@@ -4812,7 +6687,7 @@ describe('SchematicsV1', () => {
           resourceQueries,
         };
 
-        const createInventoryResult = schematicsService.createInventory(params);
+        const createInventoryResult = schematicsService.createInventory(createInventoryParams);
 
         // all methods should return a Promise
         expectToBePromise(createInventoryResult);
@@ -4820,32 +6695,47 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/inventories', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v2/inventories', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.resource_group).toEqual(resourceGroup);
-        expect(options.body.inventories_ini).toEqual(inventoriesIni);
-        expect(options.body.resource_queries).toEqual(resourceQueries);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.inventories_ini).toEqual(inventoriesIni);
+        expect(mockRequestOptions.body.resource_queries).toEqual(resourceQueries);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createInventoryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __createInventoryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __createInventoryTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createInventoryParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.createInventory(params);
+        schematicsService.createInventory(createInventoryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -4856,16 +6746,19 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('getInventory', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getInventoryTest() {
         // Construct the params object for operation getInventory
         const inventoryId = 'testString';
-        const params = {
+        const profile = 'summary';
+        const getInventoryParams = {
           inventoryId,
+          profile,
         };
 
-        const getInventoryResult = schematicsService.getInventory(params);
+        const getInventoryResult = schematicsService.getInventory(getInventoryParams);
 
         // all methods should return a Promise
         expectToBePromise(getInventoryResult);
@@ -4873,13 +6766,29 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/inventories/{inventory_id}', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/inventories/{inventory_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.inventory_id).toEqual(inventoryId);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.path.inventory_id).toEqual(inventoryId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getInventoryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getInventoryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getInventoryTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -4887,7 +6796,7 @@ describe('SchematicsV1', () => {
         const inventoryId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getInventoryParams = {
           inventoryId,
           headers: {
             Accept: userAccept,
@@ -4895,13 +6804,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getInventory(params);
+        schematicsService.getInventory(getInventoryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getInventory({});
@@ -4910,23 +6819,24 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getInventoryPromise = schematicsService.getInventory();
-        expectToBePromise(getInventoryPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getInventory();
+        } catch (e) {
+          err = e;
+        }
 
-        getInventoryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('replaceInventory', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __replaceInventoryTest() {
         // Construct the params object for operation replaceInventory
         const inventoryId = 'testString';
         const name = 'testString';
@@ -4935,7 +6845,7 @@ describe('SchematicsV1', () => {
         const resourceGroup = 'testString';
         const inventoriesIni = 'testString';
         const resourceQueries = ['testString'];
-        const params = {
+        const replaceInventoryParams = {
           inventoryId,
           name,
           description,
@@ -4945,7 +6855,7 @@ describe('SchematicsV1', () => {
           resourceQueries,
         };
 
-        const replaceInventoryResult = schematicsService.replaceInventory(params);
+        const replaceInventoryResult = schematicsService.replaceInventory(replaceInventoryParams);
 
         // all methods should return a Promise
         expectToBePromise(replaceInventoryResult);
@@ -4953,19 +6863,34 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/inventories/{inventory_id}', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v2/inventories/{inventory_id}', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.resource_group).toEqual(resourceGroup);
-        expect(options.body.inventories_ini).toEqual(inventoriesIni);
-        expect(options.body.resource_queries).toEqual(resourceQueries);
-        expect(options.path.inventory_id).toEqual(inventoryId);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.inventories_ini).toEqual(inventoriesIni);
+        expect(mockRequestOptions.body.resource_queries).toEqual(resourceQueries);
+        expect(mockRequestOptions.path.inventory_id).toEqual(inventoryId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __replaceInventoryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __replaceInventoryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __replaceInventoryTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -4973,7 +6898,7 @@ describe('SchematicsV1', () => {
         const inventoryId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const replaceInventoryParams = {
           inventoryId,
           headers: {
             Accept: userAccept,
@@ -4981,13 +6906,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.replaceInventory(params);
+        schematicsService.replaceInventory(replaceInventoryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.replaceInventory({});
@@ -4996,34 +6921,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const replaceInventoryPromise = schematicsService.replaceInventory();
-        expectToBePromise(replaceInventoryPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.replaceInventory();
+        } catch (e) {
+          err = e;
+        }
 
-        replaceInventoryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('deleteInventory', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __deleteInventoryTest() {
         // Construct the params object for operation deleteInventory
         const inventoryId = 'testString';
         const force = true;
         const propagate = true;
-        const params = {
+        const deleteInventoryParams = {
           inventoryId,
           force,
           propagate,
         };
 
-        const deleteInventoryResult = schematicsService.deleteInventory(params);
+        const deleteInventoryResult = schematicsService.deleteInventory(deleteInventoryParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteInventoryResult);
@@ -5031,15 +6957,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/inventories/{inventory_id}', 'DELETE');
+        checkUrlAndMethod(mockRequestOptions, '/v2/inventories/{inventory_id}', 'DELETE');
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'force', force);
         checkUserHeader(createRequestMock, 'propagate', propagate);
-        expect(options.path.inventory_id).toEqual(inventoryId);
+        expect(mockRequestOptions.path.inventory_id).toEqual(inventoryId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteInventoryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteInventoryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteInventoryTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -5047,7 +6988,7 @@ describe('SchematicsV1', () => {
         const inventoryId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deleteInventoryParams = {
           inventoryId,
           headers: {
             Accept: userAccept,
@@ -5055,13 +6996,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.deleteInventory(params);
+        schematicsService.deleteInventory(deleteInventoryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.deleteInventory({});
@@ -5070,122 +7011,37 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const deleteInventoryPromise = schematicsService.deleteInventory();
-        expectToBePromise(deleteInventoryPromise);
-
-        deleteInventoryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
-      });
-    });
-  });
-  describe('updateInventory', () => {
-    describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
-        // Construct the params object for operation updateInventory
-        const inventoryId = 'testString';
-        const name = 'testString';
-        const description = 'testString';
-        const location = 'us-south';
-        const resourceGroup = 'testString';
-        const inventoriesIni = 'testString';
-        const resourceQueries = ['testString'];
-        const params = {
-          inventoryId,
-          name,
-          description,
-          location,
-          resourceGroup,
-          inventoriesIni,
-          resourceQueries,
-        };
-
-        const updateInventoryResult = schematicsService.updateInventory(params);
-
-        // all methods should return a Promise
-        expectToBePromise(updateInventoryResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const options = getOptions(createRequestMock);
-
-        checkUrlAndMethod(options, '/v2/inventories/{inventory_id}', 'PATCH');
-        const expectedAccept = 'application/json';
-        const expectedContentType = 'application/json';
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.description).toEqual(description);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.resource_group).toEqual(resourceGroup);
-        expect(options.body.inventories_ini).toEqual(inventoriesIni);
-        expect(options.body.resource_queries).toEqual(resourceQueries);
-        expect(options.path.inventory_id).toEqual(inventoryId);
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const inventoryId = 'testString';
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const params = {
-          inventoryId,
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        schematicsService.updateInventory(params);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-    });
-
-    describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await schematicsService.updateInventory({});
+          await schematicsService.deleteInventory();
         } catch (e) {
           err = e;
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
-      });
-
-      test('should reject promise when required params are not given', (done) => {
-        const updateInventoryPromise = schematicsService.updateInventory();
-        expectToBePromise(updateInventoryPromise);
-
-        updateInventoryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
       });
     });
   });
+
   describe('listResourceQuery', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listResourceQueryTest() {
         // Construct the params object for operation listResourceQuery
         const offset = 0;
         const limit = 1;
         const sort = 'testString';
         const profile = 'ids';
-        const params = {
+        const listResourceQueryParams = {
           offset,
           limit,
           sort,
           profile,
         };
 
-        const listResourceQueryResult = schematicsService.listResourceQuery(params);
+        const listResourceQueryResult = schematicsService.listResourceQuery(listResourceQueryParams);
 
         // all methods should return a Promise
         expectToBePromise(listResourceQueryResult);
@@ -5193,30 +7049,45 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/resources_query', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/resources_query', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.offset).toEqual(offset);
-        expect(options.qs.limit).toEqual(limit);
-        expect(options.qs.sort).toEqual(sort);
-        expect(options.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listResourceQueryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listResourceQueryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listResourceQueryTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listResourceQueryParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.listResourceQuery(params);
+        schematicsService.listResourceQuery(listResourceQueryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -5227,6 +7098,7 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('createResourceQuery', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -5245,18 +7117,18 @@ describe('SchematicsV1', () => {
         query_select: ['testString'],
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __createResourceQueryTest() {
         // Construct the params object for operation createResourceQuery
         const type = 'vsi';
         const name = 'testString';
         const queries = [resourceQueryModel];
-        const params = {
+        const createResourceQueryParams = {
           type,
           name,
           queries,
         };
 
-        const createResourceQueryResult = schematicsService.createResourceQuery(params);
+        const createResourceQueryResult = schematicsService.createResourceQuery(createResourceQueryParams);
 
         // all methods should return a Promise
         expectToBePromise(createResourceQueryResult);
@@ -5264,29 +7136,44 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/resources_query', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v2/resources_query', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.type).toEqual(type);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.queries).toEqual(queries);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.queries).toEqual(queries);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createResourceQueryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __createResourceQueryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __createResourceQueryTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const createResourceQueryParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.createResourceQuery(params);
+        schematicsService.createResourceQuery(createResourceQueryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -5297,16 +7184,17 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('getResourcesQuery', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getResourcesQueryTest() {
         // Construct the params object for operation getResourcesQuery
         const queryId = 'testString';
-        const params = {
+        const getResourcesQueryParams = {
           queryId,
         };
 
-        const getResourcesQueryResult = schematicsService.getResourcesQuery(params);
+        const getResourcesQueryResult = schematicsService.getResourcesQuery(getResourcesQueryParams);
 
         // all methods should return a Promise
         expectToBePromise(getResourcesQueryResult);
@@ -5314,13 +7202,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/resources_query/{query_id}', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/resources_query/{query_id}', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.query_id).toEqual(queryId);
+        expect(mockRequestOptions.path.query_id).toEqual(queryId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getResourcesQueryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getResourcesQueryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getResourcesQueryTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -5328,7 +7231,7 @@ describe('SchematicsV1', () => {
         const queryId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getResourcesQueryParams = {
           queryId,
           headers: {
             Accept: userAccept,
@@ -5336,13 +7239,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getResourcesQuery(params);
+        schematicsService.getResourcesQuery(getResourcesQueryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getResourcesQuery({});
@@ -5351,20 +7254,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getResourcesQueryPromise = schematicsService.getResourcesQuery();
-        expectToBePromise(getResourcesQueryPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getResourcesQuery();
+        } catch (e) {
+          err = e;
+        }
 
-        getResourcesQueryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('replaceResourcesQuery', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -5383,20 +7287,20 @@ describe('SchematicsV1', () => {
         query_select: ['testString'],
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __replaceResourcesQueryTest() {
         // Construct the params object for operation replaceResourcesQuery
         const queryId = 'testString';
         const type = 'vsi';
         const name = 'testString';
         const queries = [resourceQueryModel];
-        const params = {
+        const replaceResourcesQueryParams = {
           queryId,
           type,
           name,
           queries,
         };
 
-        const replaceResourcesQueryResult = schematicsService.replaceResourcesQuery(params);
+        const replaceResourcesQueryResult = schematicsService.replaceResourcesQuery(replaceResourcesQueryParams);
 
         // all methods should return a Promise
         expectToBePromise(replaceResourcesQueryResult);
@@ -5404,16 +7308,31 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/resources_query/{query_id}', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v2/resources_query/{query_id}', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.type).toEqual(type);
-        expect(options.body.name).toEqual(name);
-        expect(options.body.queries).toEqual(queries);
-        expect(options.path.query_id).toEqual(queryId);
+        expect(mockRequestOptions.body.type).toEqual(type);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.queries).toEqual(queries);
+        expect(mockRequestOptions.path.query_id).toEqual(queryId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __replaceResourcesQueryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __replaceResourcesQueryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __replaceResourcesQueryTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -5421,7 +7340,7 @@ describe('SchematicsV1', () => {
         const queryId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const replaceResourcesQueryParams = {
           queryId,
           headers: {
             Accept: userAccept,
@@ -5429,13 +7348,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.replaceResourcesQuery(params);
+        schematicsService.replaceResourcesQuery(replaceResourcesQueryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.replaceResourcesQuery({});
@@ -5444,30 +7363,31 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const replaceResourcesQueryPromise = schematicsService.replaceResourcesQuery();
-        expectToBePromise(replaceResourcesQueryPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.replaceResourcesQuery();
+        } catch (e) {
+          err = e;
+        }
 
-        replaceResourcesQueryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('executeResourceQuery', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __executeResourceQueryTest() {
         // Construct the params object for operation executeResourceQuery
         const queryId = 'testString';
-        const params = {
+        const executeResourceQueryParams = {
           queryId,
         };
 
-        const executeResourceQueryResult = schematicsService.executeResourceQuery(params);
+        const executeResourceQueryResult = schematicsService.executeResourceQuery(executeResourceQueryParams);
 
         // all methods should return a Promise
         expectToBePromise(executeResourceQueryResult);
@@ -5475,13 +7395,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/resources_query/{query_id}', 'POST');
+        checkUrlAndMethod(mockRequestOptions, '/v2/resources_query/{query_id}', 'POST');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.path.query_id).toEqual(queryId);
+        expect(mockRequestOptions.path.query_id).toEqual(queryId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __executeResourceQueryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __executeResourceQueryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __executeResourceQueryTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -5489,7 +7424,7 @@ describe('SchematicsV1', () => {
         const queryId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const executeResourceQueryParams = {
           queryId,
           headers: {
             Accept: userAccept,
@@ -5497,13 +7432,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.executeResourceQuery(params);
+        schematicsService.executeResourceQuery(executeResourceQueryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.executeResourceQuery({});
@@ -5512,34 +7447,35 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const executeResourceQueryPromise = schematicsService.executeResourceQuery();
-        expectToBePromise(executeResourceQueryPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.executeResourceQuery();
+        } catch (e) {
+          err = e;
+        }
 
-        executeResourceQueryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('deleteResourcesQuery', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __deleteResourcesQueryTest() {
         // Construct the params object for operation deleteResourcesQuery
         const queryId = 'testString';
         const force = true;
         const propagate = true;
-        const params = {
+        const deleteResourcesQueryParams = {
           queryId,
           force,
           propagate,
         };
 
-        const deleteResourcesQueryResult = schematicsService.deleteResourcesQuery(params);
+        const deleteResourcesQueryResult = schematicsService.deleteResourcesQuery(deleteResourcesQueryParams);
 
         // all methods should return a Promise
         expectToBePromise(deleteResourcesQueryResult);
@@ -5547,15 +7483,30 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/resources_query/{query_id}', 'DELETE');
+        checkUrlAndMethod(mockRequestOptions, '/v2/resources_query/{query_id}', 'DELETE');
         const expectedAccept = undefined;
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
         checkUserHeader(createRequestMock, 'force', force);
         checkUserHeader(createRequestMock, 'propagate', propagate);
-        expect(options.path.query_id).toEqual(queryId);
+        expect(mockRequestOptions.path.query_id).toEqual(queryId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteResourcesQueryTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteResourcesQueryTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteResourcesQueryTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -5563,7 +7514,7 @@ describe('SchematicsV1', () => {
         const queryId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const deleteResourcesQueryParams = {
           queryId,
           headers: {
             Accept: userAccept,
@@ -5571,13 +7522,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.deleteResourcesQuery(params);
+        schematicsService.deleteResourcesQuery(deleteResourcesQueryParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.deleteResourcesQuery({});
@@ -5586,30 +7537,516 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const deleteResourcesQueryPromise = schematicsService.deleteResourcesQuery();
-        expectToBePromise(deleteResourcesQueryPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.deleteResourcesQuery();
+        } catch (e) {
+          err = e;
+        }
 
-        deleteResourcesQueryPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
+  describe('listAgent', () => {
+    describe('positive tests', () => {
+      function __listAgentTest() {
+        // Construct the params object for operation listAgent
+        const offset = 0;
+        const limit = 1;
+        const profile = 'summary';
+        const filter = 'all';
+        const listAgentParams = {
+          offset,
+          limit,
+          profile,
+          filter,
+        };
+
+        const listAgentResult = schematicsService.listAgent(listAgentParams);
+
+        // all methods should return a Promise
+        expectToBePromise(listAgentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/agents', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.offset).toEqual(offset);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.qs.filter).toEqual(filter);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listAgentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listAgentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listAgentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const listAgentParams = {
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.listAgent(listAgentParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+
+      test('should not have any problems when no parameters are passed in', () => {
+        // invoke the method with no parameters
+        schematicsService.listAgent({});
+        checkForSuccessfulExecution(createRequestMock);
+      });
+    });
+  });
+
+  describe('registerAgent', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // AgentUserState
+      const agentUserStateModel = {
+        state: 'enable',
+      };
+
+      function __registerAgentTest() {
+        // Construct the params object for operation registerAgent
+        const name = 'MyDevAgent';
+        const agentLocation = 'us-south';
+        const location = 'us-south';
+        const profileId = 'testString';
+        const description = 'Register agent';
+        const resourceGroup = 'testString';
+        const tags = ['testString'];
+        const userState = agentUserStateModel;
+        const registerAgentParams = {
+          name,
+          agentLocation,
+          location,
+          profileId,
+          description,
+          resourceGroup,
+          tags,
+          userState,
+        };
+
+        const registerAgentResult = schematicsService.registerAgent(registerAgentParams);
+
+        // all methods should return a Promise
+        expectToBePromise(registerAgentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/agents', 'POST');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.agent_location).toEqual(agentLocation);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.profile_id).toEqual(profileId);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.user_state).toEqual(userState);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __registerAgentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __registerAgentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __registerAgentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const name = 'MyDevAgent';
+        const agentLocation = 'us-south';
+        const location = 'us-south';
+        const profileId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const registerAgentParams = {
+          name,
+          agentLocation,
+          location,
+          profileId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.registerAgent(registerAgentParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.registerAgent({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.registerAgent();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('getAgent', () => {
+    describe('positive tests', () => {
+      function __getAgentTest() {
+        // Construct the params object for operation getAgent
+        const agentId = 'testString';
+        const profile = 'summary';
+        const getAgentParams = {
+          agentId,
+          profile,
+        };
+
+        const getAgentResult = schematicsService.getAgent(getAgentParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getAgentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/agents/{agent_id}', 'GET');
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.qs.profile).toEqual(profile);
+        expect(mockRequestOptions.path.agent_id).toEqual(agentId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getAgentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getAgentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getAgentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const agentId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getAgentParams = {
+          agentId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.getAgent(getAgentParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.getAgent({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getAgent();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('deleteAgent', () => {
+    describe('positive tests', () => {
+      function __deleteAgentTest() {
+        // Construct the params object for operation deleteAgent
+        const agentId = 'testString';
+        const deleteAgentParams = {
+          agentId,
+        };
+
+        const deleteAgentResult = schematicsService.deleteAgent(deleteAgentParams);
+
+        // all methods should return a Promise
+        expectToBePromise(deleteAgentResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/agents/{agent_id}', 'DELETE');
+        const expectedAccept = undefined;
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.agent_id).toEqual(agentId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __deleteAgentTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __deleteAgentTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __deleteAgentTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const agentId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const deleteAgentParams = {
+          agentId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.deleteAgent(deleteAgentParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.deleteAgent({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.deleteAgent();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('updateAgentRegistration', () => {
+    describe('positive tests', () => {
+      // Request models needed by this operation.
+
+      // AgentUserState
+      const agentUserStateModel = {
+        state: 'enable',
+      };
+
+      function __updateAgentRegistrationTest() {
+        // Construct the params object for operation updateAgentRegistration
+        const agentId = 'testString';
+        const name = 'MyDevAgent';
+        const agentLocation = 'us-south';
+        const location = 'us-south';
+        const profileId = 'testString';
+        const description = 'Register agent';
+        const resourceGroup = 'testString';
+        const tags = ['testString'];
+        const userState = agentUserStateModel;
+        const updateAgentRegistrationParams = {
+          agentId,
+          name,
+          agentLocation,
+          location,
+          profileId,
+          description,
+          resourceGroup,
+          tags,
+          userState,
+        };
+
+        const updateAgentRegistrationResult = schematicsService.updateAgentRegistration(updateAgentRegistrationParams);
+
+        // all methods should return a Promise
+        expectToBePromise(updateAgentRegistrationResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/agents/{agent_id}', 'PATCH');
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.name).toEqual(name);
+        expect(mockRequestOptions.body.agent_location).toEqual(agentLocation);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.profile_id).toEqual(profileId);
+        expect(mockRequestOptions.body.description).toEqual(description);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.tags).toEqual(tags);
+        expect(mockRequestOptions.body.user_state).toEqual(userState);
+        expect(mockRequestOptions.path.agent_id).toEqual(agentId);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateAgentRegistrationTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __updateAgentRegistrationTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __updateAgentRegistrationTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const agentId = 'testString';
+        const name = 'MyDevAgent';
+        const agentLocation = 'us-south';
+        const location = 'us-south';
+        const profileId = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const updateAgentRegistrationParams = {
+          agentId,
+          name,
+          agentLocation,
+          location,
+          profileId,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        schematicsService.updateAgentRegistration(updateAgentRegistrationParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await schematicsService.updateAgentRegistration({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.updateAgentRegistration();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
   describe('getKmsSettings', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __getKmsSettingsTest() {
         // Construct the params object for operation getKmsSettings
         const location = 'testString';
-        const params = {
+        const getKmsSettingsParams = {
           location,
         };
 
-        const getKmsSettingsResult = schematicsService.getKmsSettings(params);
+        const getKmsSettingsResult = schematicsService.getKmsSettings(getKmsSettingsParams);
 
         // all methods should return a Promise
         expectToBePromise(getKmsSettingsResult);
@@ -5617,13 +8054,28 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/settings/kms', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/kms', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.location).toEqual(location);
+        expect(mockRequestOptions.qs.location).toEqual(location);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getKmsSettingsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __getKmsSettingsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __getKmsSettingsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -5631,7 +8083,7 @@ describe('SchematicsV1', () => {
         const location = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const getKmsSettingsParams = {
           location,
           headers: {
             Accept: userAccept,
@@ -5639,13 +8091,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.getKmsSettings(params);
+        schematicsService.getKmsSettings(getKmsSettingsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.getKmsSettings({});
@@ -5654,20 +8106,21 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const getKmsSettingsPromise = schematicsService.getKmsSettings();
-        expectToBePromise(getKmsSettingsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.getKmsSettings();
+        } catch (e) {
+          err = e;
+        }
 
-        getKmsSettingsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });
+
   describe('updateKmsSettings', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -5686,14 +8139,14 @@ describe('SchematicsV1', () => {
         key_crn: 'testString',
       };
 
-      test('should pass the right params to createRequest', () => {
+      function __updateKmsSettingsTest() {
         // Construct the params object for operation updateKmsSettings
         const location = 'testString';
         const encryptionScheme = 'testString';
         const resourceGroup = 'testString';
         const primaryCrk = kmsSettingsPrimaryCrkModel;
         const secondaryCrk = kmsSettingsSecondaryCrkModel;
-        const params = {
+        const updateKmsSettingsParams = {
           location,
           encryptionScheme,
           resourceGroup,
@@ -5701,7 +8154,7 @@ describe('SchematicsV1', () => {
           secondaryCrk,
         };
 
-        const updateKmsSettingsResult = schematicsService.updateKmsSettings(params);
+        const updateKmsSettingsResult = schematicsService.updateKmsSettings(updateKmsSettingsParams);
 
         // all methods should return a Promise
         expectToBePromise(updateKmsSettingsResult);
@@ -5709,31 +8162,46 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/settings/kms', 'PUT');
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/kms', 'PUT');
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.body.location).toEqual(location);
-        expect(options.body.encryption_scheme).toEqual(encryptionScheme);
-        expect(options.body.resource_group).toEqual(resourceGroup);
-        expect(options.body.primary_crk).toEqual(primaryCrk);
-        expect(options.body.secondary_crk).toEqual(secondaryCrk);
+        expect(mockRequestOptions.body.location).toEqual(location);
+        expect(mockRequestOptions.body.encryption_scheme).toEqual(encryptionScheme);
+        expect(mockRequestOptions.body.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.body.primary_crk).toEqual(primaryCrk);
+        expect(mockRequestOptions.body.secondary_crk).toEqual(secondaryCrk);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __updateKmsSettingsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __updateKmsSettingsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __updateKmsSettingsTest();
       });
 
       test('should prioritize user-given headers', () => {
         // parameters
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const updateKmsSettingsParams = {
           headers: {
             Accept: userAccept,
             'Content-Type': userContentType,
           },
         };
 
-        schematicsService.updateKmsSettings(params);
+        schematicsService.updateKmsSettings(updateKmsSettingsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
 
@@ -5744,16 +8212,17 @@ describe('SchematicsV1', () => {
       });
     });
   });
+
   describe('listKms', () => {
     describe('positive tests', () => {
-      test('should pass the right params to createRequest', () => {
+      function __listKmsTest() {
         // Construct the params object for operation listKms
         const encryptionScheme = 'testString';
         const location = 'testString';
         const resourceGroup = 'testString';
         const limit = 1;
         const sort = 'testString';
-        const params = {
+        const listKmsParams = {
           encryptionScheme,
           location,
           resourceGroup,
@@ -5761,7 +8230,7 @@ describe('SchematicsV1', () => {
           sort,
         };
 
-        const listKmsResult = schematicsService.listKms(params);
+        const listKmsResult = schematicsService.listKms(listKmsParams);
 
         // all methods should return a Promise
         expectToBePromise(listKmsResult);
@@ -5769,17 +8238,32 @@ describe('SchematicsV1', () => {
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
 
-        const options = getOptions(createRequestMock);
+        const mockRequestOptions = getOptions(createRequestMock);
 
-        checkUrlAndMethod(options, '/v2/settings/kms_instances', 'GET');
+        checkUrlAndMethod(mockRequestOptions, '/v2/settings/kms_instances', 'GET');
         const expectedAccept = 'application/json';
         const expectedContentType = undefined;
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(options.qs.encryption_scheme).toEqual(encryptionScheme);
-        expect(options.qs.location).toEqual(location);
-        expect(options.qs.resource_group).toEqual(resourceGroup);
-        expect(options.qs.limit).toEqual(limit);
-        expect(options.qs.sort).toEqual(sort);
+        expect(mockRequestOptions.qs.encryption_scheme).toEqual(encryptionScheme);
+        expect(mockRequestOptions.qs.location).toEqual(location);
+        expect(mockRequestOptions.qs.resource_group).toEqual(resourceGroup);
+        expect(mockRequestOptions.qs.limit).toEqual(limit);
+        expect(mockRequestOptions.qs.sort).toEqual(sort);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __listKmsTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.enableRetries();
+        __listKmsTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        schematicsService.disableRetries();
+        __listKmsTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -5788,7 +8272,7 @@ describe('SchematicsV1', () => {
         const location = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const params = {
+        const listKmsParams = {
           encryptionScheme,
           location,
           headers: {
@@ -5797,13 +8281,13 @@ describe('SchematicsV1', () => {
           },
         };
 
-        schematicsService.listKms(params);
+        schematicsService.listKms(listKmsParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
 
     describe('negative tests', () => {
-      test('should enforce required parameters', async (done) => {
+      test('should enforce required parameters', async () => {
         let err;
         try {
           await schematicsService.listKms({});
@@ -5812,17 +8296,17 @@ describe('SchematicsV1', () => {
         }
 
         expect(err.message).toMatch(/Missing required parameters/);
-        done();
       });
 
-      test('should reject promise when required params are not given', (done) => {
-        const listKmsPromise = schematicsService.listKms();
-        expectToBePromise(listKmsPromise);
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await schematicsService.listKms();
+        } catch (e) {
+          err = e;
+        }
 
-        listKmsPromise.catch((err) => {
-          expect(err.message).toMatch(/Missing required parameters/);
-          done();
-        });
+        expect(err.message).toMatch(/Missing required parameters/);
       });
     });
   });


### PR DESCRIPTION
Summary
We have updated [node-sdk](https://github.com/IBM/schematics-node-sdk) package for node -language with support v1 API’s.
Added 2 new files within the node-sdk package that will support building of both v1 api's during setup.

    schematics/v1.ts
    test/unit/schematics.v1.test.js
    README.md